### PR TITLE
[#13] feat: 로그인 기능 구현

### DIFF
--- a/src/main/java/com/sparta/spangeats/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/sparta/spangeats/domain/auth/controller/AuthController.java
@@ -17,18 +17,18 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api")
+@RequestMapping("/api/auth")
 public class AuthController {
 
     private final AuthService authService;
 
-    @PostMapping("/auth/signup")
+    @PostMapping("/signup")
     public ResponseEntity<String> signup(@Valid @RequestBody SignupRequestDto requestDto) {
         authService.signup(requestDto);
         return ResponseEntity.status(HttpStatus.CREATED).body("회원 가입이 완료되었습니다!");
     }
 
-    @PostMapping("/auth/login")
+    @PostMapping("/login")
     public ResponseEntity<AuthResponseDto> signup(@RequestBody LoginRequestDto requestDto) {
         AuthResponseDto bearerJwt = authService.login(requestDto);
         return ResponseEntity.status(HttpStatus.CREATED).body(bearerJwt);

--- a/src/main/java/com/sparta/spangeats/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/sparta/spangeats/domain/auth/controller/AuthController.java
@@ -23,9 +23,9 @@ public class AuthController {
     private final AuthService authService;
 
     @PostMapping("/auth/signup")
-    public ResponseEntity<AuthResponseDto> signup(@Valid @RequestBody SignupRequestDto requestDto) {
-        AuthResponseDto bearerJwt = authService.signup(requestDto);
-        return ResponseEntity.status(HttpStatus.CREATED).body(bearerJwt);
+    public ResponseEntity<String> signup(@Valid @RequestBody SignupRequestDto requestDto) {
+        authService.signup(requestDto);
+        return ResponseEntity.status(HttpStatus.CREATED).body("회원 가입이 완료되었습니다!");
     }
 
     @PostMapping("/auth/login")

--- a/src/main/java/com/sparta/spangeats/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/sparta/spangeats/domain/auth/controller/AuthController.java
@@ -1,6 +1,8 @@
 package com.sparta.spangeats.domain.auth.controller;
 
+import com.sparta.spangeats.domain.auth.dto.request.LoginRequestDto;
 import com.sparta.spangeats.domain.auth.dto.request.SignupRequestDto;
+import com.sparta.spangeats.domain.auth.dto.response.AuthResponseDto;
 import com.sparta.spangeats.domain.auth.service.AuthService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -21,11 +23,15 @@ public class AuthController {
     private final AuthService authService;
 
     @PostMapping("/auth/signup")
-    public ResponseEntity<String> signup(@Valid @RequestBody SignupRequestDto requestDto) {
-        log.info("회원가입 요청 시작: " + requestDto);
-        String bearerJwt = String.valueOf(authService.signup(requestDto));
-        log.info("회원가입 완료");
-        return ResponseEntity.status(HttpStatus.CREATED).body("회원가입 완료! \n Bearer JWT : " + bearerJwt);
+    public ResponseEntity<AuthResponseDto> signup(@Valid @RequestBody SignupRequestDto requestDto) {
+        AuthResponseDto bearerJwt = authService.signup(requestDto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(bearerJwt);
+    }
+
+    @PostMapping("/auth/login")
+    public ResponseEntity<AuthResponseDto> signup(@RequestBody LoginRequestDto requestDto) {
+        AuthResponseDto bearerJwt = authService.login(requestDto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(bearerJwt);
     }
 
 }

--- a/src/main/java/com/sparta/spangeats/domain/auth/dto/response/AuthResponseDto.java
+++ b/src/main/java/com/sparta/spangeats/domain/auth/dto/response/AuthResponseDto.java
@@ -1,4 +1,4 @@
 package com.sparta.spangeats.domain.auth.dto.response;
 
-public class SignupResponse {
+public record AuthResponseDto(String bearerToken) {
 }

--- a/src/main/java/com/sparta/spangeats/domain/auth/dto/response/LoginResponseDto.java
+++ b/src/main/java/com/sparta/spangeats/domain/auth/dto/response/LoginResponseDto.java
@@ -1,4 +1,0 @@
-package com.sparta.spangeats.domain.auth.dto.response;
-
-public record LoginResponseDto(String bearerToken) {
-}

--- a/src/main/java/com/sparta/spangeats/domain/auth/service/AuthService.java
+++ b/src/main/java/com/sparta/spangeats/domain/auth/service/AuthService.java
@@ -25,7 +25,7 @@ public class AuthService {
     private final JwtUtil jwtUtil;
 
     @Transactional
-    public AuthResponseDto signup(SignupRequestDto requestDto) {
+    public void signup(SignupRequestDto requestDto) {
         if (memberRepository.existsByEmail(requestDto.email())) {
             throw new AuthException("이미 존재하는 이메일 입니다.");
         }
@@ -45,10 +45,6 @@ public class AuthService {
                 memberRole,
                 requestDto.phoneNumber());
         memberRepository.save(member);
-
-        String bearerToken = jwtUtil.createToken(member.getEmail(), member.getMemberRole());
-
-        return new AuthResponseDto(bearerToken);
     }
 
     public AuthResponseDto login(LoginRequestDto requestDto) {

--- a/src/main/java/com/sparta/spangeats/domain/review/entity/Review.java
+++ b/src/main/java/com/sparta/spangeats/domain/review/entity/Review.java
@@ -26,10 +26,10 @@ public class Review extends Timestamped {
 //    @JoinColumn(name = "todo_id", nullable = false)
     private Long orderId;
 
-    private Long memberId;
+//    private Long memberId;
 
     public Review(Long memberId, Long orderId, Long star, String contents) {
-        this.memberId = memberId;
+//        this.memberId = memberId;
         this.orderId = orderId;
         this.star = star;
         this.contents = contents;


### PR DESCRIPTION
 **issue/13**

 - 로그인 시 이메일과 비밀번호 검증 후 JWT 토큰 발급
  - SignupResponseDto와 LoginResponseDto를 하나의 AuthResponseDto로 통일
  - 유효한 이메일과 비밀번호 입력 시 `AuthResponseDto`를 통해 `bearerToken` 반환
  - 잘못된 이메일 또는 비밀번호 입력 시 `AuthException` 발생으로 에러 처리
  - 서버 동작에 방해되는 리뷰 클래스의 memberId 주석처리함
  
 - 피드백 적용 완료


  ** 구현 예정 1**
 - 멤버 엔티티에 enum으로 status를 만들어 삭제된 계정인지를 판별하는 필드를 생성하여 회원 탈퇴 기능 구현 예정
 
  ** 구현 예정 2**
 - MemberRole에 ADMIN 추가 및 관리자 계정 권한 검증 기능 구현 예정 
 - 회원가입 시 ADMIN 역할을 선택할 경우, 추가로 관리자 암호 입력을 요구
 - 입력한 관리자 암호가 시스템에 저장된 ADMIN_TOKEN과 일치할 때에만 관리자 계정 생성 허용
 - ADMIN 계정은 모든 권한을 가지며, 이를 통해 관리자 기능 수행 가능