### PR TITLE
feat : 회원 탈퇴 기능 추가 (Soft Delete 적용)

### DIFF
--- a/src/main/java/com/sparta/spangeats/SpangEatsApplication.java
+++ b/src/main/java/com/sparta/spangeats/SpangEatsApplication.java
@@ -2,9 +2,11 @@ package com.sparta.spangeats;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableScheduling
+@EnableJpaAuditing
 @SpringBootApplication
 public class SpangEatsApplication {
 

--- a/src/main/java/com/sparta/spangeats/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/sparta/spangeats/domain/auth/controller/AuthController.java
@@ -4,6 +4,7 @@ import com.sparta.spangeats.domain.auth.dto.request.LoginRequestDto;
 import com.sparta.spangeats.domain.auth.dto.request.SignupRequestDto;
 import com.sparta.spangeats.domain.auth.dto.response.AuthResponseDto;
 import com.sparta.spangeats.domain.auth.service.AuthService;
+import com.sparta.spangeats.security.filter.UserDetailsImpl;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/sparta/spangeats/domain/auth/service/AuthService.java
+++ b/src/main/java/com/sparta/spangeats/domain/auth/service/AuthService.java
@@ -48,7 +48,6 @@ public class AuthService {
                 memberRole,
                 requestDto.phoneNumber()
         );
-//        member.setMemberStatus(MemberStatus.ACTIVE);
         memberRepository.save(member);
     }
 

--- a/src/main/java/com/sparta/spangeats/domain/auth/service/AuthService.java
+++ b/src/main/java/com/sparta/spangeats/domain/auth/service/AuthService.java
@@ -6,9 +6,12 @@ import com.sparta.spangeats.domain.auth.dto.response.AuthResponseDto;
 import com.sparta.spangeats.domain.auth.exception.AuthException;
 import com.sparta.spangeats.domain.member.entity.Member;
 import com.sparta.spangeats.domain.member.enums.MemberRole;
+import com.sparta.spangeats.domain.member.enums.MemberStatus;
+import com.sparta.spangeats.domain.member.exception.MemberException;
 import com.sparta.spangeats.domain.member.repository.MemberRepository;
 import com.sparta.spangeats.security.config.CustomPasswordEncoder;
 import com.sparta.spangeats.security.config.JwtUtil;
+import com.sparta.spangeats.security.filter.UserDetailsImpl;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -27,7 +30,7 @@ public class AuthService {
     @Transactional
     public void signup(SignupRequestDto requestDto) {
         if (memberRepository.existsByEmail(requestDto.email())) {
-            throw new AuthException("이미 존재하는 이메일 입니다.");
+            throw new AuthException("이미 존재하는 이메일, 또는 회원 탈퇴한 이메일입니다.");
         }
 
         if (memberRepository.existsByNickname(requestDto.nickname())) {
@@ -43,7 +46,9 @@ public class AuthService {
                 encodedPassword,
                 requestDto.nickname(),
                 memberRole,
-                requestDto.phoneNumber());
+                requestDto.phoneNumber()
+        );
+//        member.setMemberStatus(MemberStatus.ACTIVE);
         memberRepository.save(member);
     }
 

--- a/src/main/java/com/sparta/spangeats/domain/member/controller/MemberController.java
+++ b/src/main/java/com/sparta/spangeats/domain/member/controller/MemberController.java
@@ -1,5 +1,32 @@
 package com.sparta.spangeats.domain.member.controller;
 
+import com.sparta.spangeats.domain.member.dto.SignoutRequestDto;
+import com.sparta.spangeats.domain.member.service.MemberService;
+import com.sparta.spangeats.security.filter.UserDetailsImpl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/member")
 public class MemberController {
+
+    private final MemberService memberService;
+
+    //회원 탈퇴 기능
+    @DeleteMapping("/signout")
+    public ResponseEntity<String> signout(@RequestBody SignoutRequestDto requestDto,
+                                          @AuthenticationPrincipal UserDetailsImpl userDetails) {
+
+        memberService.signout(requestDto, userDetails);
+        return ResponseEntity.status(HttpStatus.OK).body("회원 탈퇴 완료! 중복된 이메일로 재가입이 불가합니다.");
+
+    }
 
 }

--- a/src/main/java/com/sparta/spangeats/domain/member/dto/SignoutRequestDto.java
+++ b/src/main/java/com/sparta/spangeats/domain/member/dto/SignoutRequestDto.java
@@ -1,0 +1,4 @@
+package com.sparta.spangeats.domain.member.dto;
+
+public record SignoutRequestDto(String password) {
+}

--- a/src/main/java/com/sparta/spangeats/domain/member/entity/Member.java
+++ b/src/main/java/com/sparta/spangeats/domain/member/entity/Member.java
@@ -2,11 +2,14 @@ package com.sparta.spangeats.domain.member.entity;
 
 import com.sparta.spangeats.common.Timestamped;
 import com.sparta.spangeats.domain.member.enums.MemberRole;
+import com.sparta.spangeats.domain.member.enums.MemberStatus;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Setter
 @Entity
 @NoArgsConstructor
 @Table(name = "member")
@@ -28,6 +31,9 @@ public class Member extends Timestamped {
 
     @Column(nullable = false)
     private String phoneNumber;
+
+    @Enumerated(EnumType.STRING)
+    private MemberStatus memberStatus = MemberStatus.ACTIVE;
 
     public Member(String email, String password, String nickname, MemberRole role, String phoneNumber) {
         this.email = email;

--- a/src/main/java/com/sparta/spangeats/domain/member/enums/MemberStatus.java
+++ b/src/main/java/com/sparta/spangeats/domain/member/enums/MemberStatus.java
@@ -1,9 +1,6 @@
 package com.sparta.spangeats.domain.member.enums;
 
-import com.sparta.spangeats.domain.member.exception.MemberException;
 import lombok.RequiredArgsConstructor;
-
-import java.util.Arrays;
 
 @RequiredArgsConstructor
 public enum MemberStatus {
@@ -11,17 +8,6 @@ public enum MemberStatus {
     DELETED(Status.DELETED);
 
     private final String status;
-
-    public static MemberStatus of(String status) {
-        return Arrays.stream(MemberStatus.values())
-                .filter(r -> r.name().equalsIgnoreCase(status))
-                .findFirst()
-                .orElseThrow(() -> new MemberException("유효하지 않은 사용자 Status : " + status));
-    }
-
-    public String getStatus() {
-        return this.status;
-    }
 
     public static class Status {
         public static final String ACTIVE = "ACTIVE";

--- a/src/main/java/com/sparta/spangeats/domain/member/enums/MemberStatus.java
+++ b/src/main/java/com/sparta/spangeats/domain/member/enums/MemberStatus.java
@@ -1,0 +1,30 @@
+package com.sparta.spangeats.domain.member.enums;
+
+import com.sparta.spangeats.domain.member.exception.MemberException;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+
+@RequiredArgsConstructor
+public enum MemberStatus {
+    ACTIVE(Status.ACTIVE),
+    DELETED(Status.DELETED);
+
+    private final String status;
+
+    public static MemberStatus of(String status) {
+        return Arrays.stream(MemberStatus.values())
+                .filter(r -> r.name().equalsIgnoreCase(status))
+                .findFirst()
+                .orElseThrow(() -> new MemberException("유효하지 않은 사용자 Status : " + status));
+    }
+
+    public String getStatus() {
+        return this.status;
+    }
+
+    public static class Status {
+        public static final String ACTIVE = "ACTIVE";
+        public static final String DELETED = "DELETED";
+    }
+}

--- a/src/main/java/com/sparta/spangeats/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/sparta/spangeats/domain/member/repository/MemberRepository.java
@@ -17,6 +17,4 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByEmail(String email);
 
     boolean existsByNickname(String nickname);
-
-    boolean findByMemberStatus(MemberStatus memberStatus);
 }

--- a/src/main/java/com/sparta/spangeats/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/sparta/spangeats/domain/member/repository/MemberRepository.java
@@ -1,9 +1,13 @@
 package com.sparta.spangeats.domain.member.repository;
 
 import com.sparta.spangeats.domain.member.entity.Member;
+import com.sparta.spangeats.domain.member.enums.MemberStatus;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
@@ -14,5 +18,5 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     boolean existsByNickname(String nickname);
 
-    void deleteByEmail(String username);
+    boolean findByMemberStatus(MemberStatus memberStatus);
 }

--- a/src/main/java/com/sparta/spangeats/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/sparta/spangeats/domain/member/repository/MemberRepository.java
@@ -13,4 +13,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByEmail(String email);
 
     boolean existsByNickname(String nickname);
+
+    void deleteByEmail(String username);
 }

--- a/src/main/java/com/sparta/spangeats/domain/member/service/MemberService.java
+++ b/src/main/java/com/sparta/spangeats/domain/member/service/MemberService.java
@@ -1,7 +1,45 @@
 package com.sparta.spangeats.domain.member.service;
 
+import com.sparta.spangeats.domain.auth.dto.request.LoginRequestDto;
+import com.sparta.spangeats.domain.auth.dto.response.AuthResponseDto;
+import com.sparta.spangeats.domain.auth.exception.AuthException;
+import com.sparta.spangeats.domain.member.dto.SignoutRequestDto;
+import com.sparta.spangeats.domain.member.entity.Member;
+import com.sparta.spangeats.domain.member.exception.MemberException;
+import com.sparta.spangeats.domain.member.repository.MemberRepository;
+import com.sparta.spangeats.security.config.CustomPasswordEncoder;
+import com.sparta.spangeats.security.filter.UserDetailsImpl;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@RequiredArgsConstructor
 public class MemberService {
+
+    private final CustomPasswordEncoder passwordEncoder;
+    private final MemberRepository memberRepository;
+
+//    public AuthResponseDto login(LoginRequestDto requestDto) {
+//        Member member = memberRepository.findByEmail(requestDto.email())
+//                .orElseThrow(() -> new AuthException("가입되지 않은 유저입니다."));
+//
+//        if (!passwordEncoder.matches(requestDto.password(), member.getPassword())) {
+//            throw new AuthException("잘못된 비밀번호입니다.");
+//        }
+//
+//        String bearerToken = jwtUtil.createToken(member.getEmail(), member.getMemberRole());
+//
+//        return new AuthResponseDto(bearerToken);
+//    }
+
+    @Transactional
+    public void signout(SignoutRequestDto requestDto, UserDetailsImpl userDetails) {
+
+        if (!passwordEncoder.matches(requestDto.password(), userDetails.getPassword())) {
+            throw new MemberException("잘못된 비밀번호입니다.");
+        }
+
+        memberRepository.deleteByEmail(userDetails.getUsername());
+    }
 }

--- a/src/main/java/com/sparta/spangeats/domain/member/service/MemberService.java
+++ b/src/main/java/com/sparta/spangeats/domain/member/service/MemberService.java
@@ -5,6 +5,7 @@ import com.sparta.spangeats.domain.auth.dto.response.AuthResponseDto;
 import com.sparta.spangeats.domain.auth.exception.AuthException;
 import com.sparta.spangeats.domain.member.dto.SignoutRequestDto;
 import com.sparta.spangeats.domain.member.entity.Member;
+import com.sparta.spangeats.domain.member.enums.MemberStatus;
 import com.sparta.spangeats.domain.member.exception.MemberException;
 import com.sparta.spangeats.domain.member.repository.MemberRepository;
 import com.sparta.spangeats.security.config.CustomPasswordEncoder;
@@ -20,26 +21,19 @@ public class MemberService {
     private final CustomPasswordEncoder passwordEncoder;
     private final MemberRepository memberRepository;
 
-//    public AuthResponseDto login(LoginRequestDto requestDto) {
-//        Member member = memberRepository.findByEmail(requestDto.email())
-//                .orElseThrow(() -> new AuthException("가입되지 않은 유저입니다."));
-//
-//        if (!passwordEncoder.matches(requestDto.password(), member.getPassword())) {
-//            throw new AuthException("잘못된 비밀번호입니다.");
-//        }
-//
-//        String bearerToken = jwtUtil.createToken(member.getEmail(), member.getMemberRole());
-//
-//        return new AuthResponseDto(bearerToken);
-//    }
-
     @Transactional
     public void signout(SignoutRequestDto requestDto, UserDetailsImpl userDetails) {
 
         if (!passwordEncoder.matches(requestDto.password(), userDetails.getPassword())) {
-            throw new MemberException("잘못된 비밀번호입니다.");
+            throw new MemberException("사용자 아이디와 비빌번호가 일치하지 않습니다.");
         }
 
-        memberRepository.deleteByEmail(userDetails.getUsername());
+        if (userDetails.getMemberStatus().equals(MemberStatus.DELETED)) {
+            throw new MemberException("이미 탈퇴한 사용자입니다.");
+        }
+
+
+        userDetails.getMember().setMemberStatus(MemberStatus.DELETED);
+        memberRepository.save(userDetails.getMember());
     }
 }

--- a/src/main/java/com/sparta/spangeats/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/sparta/spangeats/security/filter/JwtAuthenticationFilter.java
@@ -50,7 +50,7 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
                                             HttpServletResponse response,
                                             FilterChain chain,
                                             Authentication authResult) {
-        String email = ((UserDetailsImpl) authResult.getPrincipal()).getUsername();
+        String email = ((UserDetailsImpl) authResult.getPrincipal()).getEmail();
         MemberRole role = ((UserDetailsImpl) authResult.getPrincipal()).getMember().getMemberRole();
 
         String token = jwtUtil.createToken(email, role);

--- a/src/main/java/com/sparta/spangeats/security/filter/UserDetailsImpl.java
+++ b/src/main/java/com/sparta/spangeats/security/filter/UserDetailsImpl.java
@@ -2,6 +2,7 @@ package com.sparta.spangeats.security.filter;
 
 import com.sparta.spangeats.domain.member.entity.Member;
 import com.sparta.spangeats.domain.member.enums.MemberRole;
+import com.sparta.spangeats.domain.member.enums.MemberStatus;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;

--- a/src/main/java/com/sparta/spangeats/security/filter/UserDetailsImpl.java
+++ b/src/main/java/com/sparta/spangeats/security/filter/UserDetailsImpl.java
@@ -19,7 +19,7 @@ public class UserDetailsImpl implements UserDetails {
 
     @Override
     public String getUsername() {
-        return member.getNickname();
+        return member.getEmail();
     }
 
     @Override
@@ -41,6 +41,10 @@ public class UserDetailsImpl implements UserDetails {
 
     public MemberRole getMemberRole() {
         return member.getMemberRole();
+    }
+
+    public MemberStatus getMemberStatus() {
+        return member.getMemberStatus();
     }
 
     @Override


### PR DESCRIPTION
Issue/14

[#14] 회원 탈퇴 기능 추가 (Soft Delete 적용)
      
      - 회원 탈퇴 기능 구현: 회원 탈퇴 상태를 DELETED로 업데이트하여 소프트 삭제 처리
      - `MemberStatus` ENUM 클래스 추가: 회원 상태를 관리하며, `ACTIVE`과 `DELETED` 상태로 구분하여 소프트 삭제 여부를 판단
      - 탈퇴 예외 처리 추가:
          * 아이디와 비밀번호가 일치하지 않을 경우 예외 발생
          * 이미 탈퇴한 사용자일 경우 예외 발생
       - 탈퇴 상태 업데이트 시 자동으로 수정일이 업데이트되도록 Auditing 적용
       - 회원 탈퇴 시 데이터를 보존하면서 재가입 방지 기능 추가
       
       ** 추가할 기능 ** 
       - ADMIN 계정은 모든 권한을 가지며, 이를 통해 관리자 기능 수행 가능