### PR TITLE
feat: 회원 정보 조회 기능 추가

### DIFF
--- a/src/main/java/com/sparta/spangeats/domain/member/controller/MemberController.java
+++ b/src/main/java/com/sparta/spangeats/domain/member/controller/MemberController.java
@@ -1,16 +1,15 @@
 package com.sparta.spangeats.domain.member.controller;
 
-import com.sparta.spangeats.domain.member.dto.SignoutRequestDto;
+import com.sparta.spangeats.domain.member.dto.request.SignoutRequestDto;
+import com.sparta.spangeats.domain.member.dto.response.MemberInfoResponseDto;
+import com.sparta.spangeats.domain.member.entity.Member;
 import com.sparta.spangeats.domain.member.service.MemberService;
 import com.sparta.spangeats.security.filter.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -19,7 +18,6 @@ public class MemberController {
 
     private final MemberService memberService;
 
-    //회원 탈퇴 기능
     @DeleteMapping("/signout")
     public ResponseEntity<String> signout(@RequestBody SignoutRequestDto requestDto,
                                           @AuthenticationPrincipal UserDetailsImpl userDetails) {
@@ -27,6 +25,13 @@ public class MemberController {
         memberService.signout(requestDto, userDetails);
         return ResponseEntity.status(HttpStatus.OK).body("회원 탈퇴 완료! 중복된 이메일로 재가입이 불가합니다.");
 
+    }
+
+    @GetMapping
+    public ResponseEntity<MemberInfoResponseDto> getMemberInfo(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+
+        MemberInfoResponseDto responseDto = memberService.getMemberInfo(userDetails);
+        return ResponseEntity.status(HttpStatus.OK).body(responseDto);
     }
 
 }

--- a/src/main/java/com/sparta/spangeats/domain/member/dto/MemberRequestDto.java
+++ b/src/main/java/com/sparta/spangeats/domain/member/dto/MemberRequestDto.java
@@ -1,4 +1,0 @@
-package com.sparta.spangeats.domain.member.dto;
-
-public record MemberRequestDto() {
-}

--- a/src/main/java/com/sparta/spangeats/domain/member/dto/MemberResponseDto.java
+++ b/src/main/java/com/sparta/spangeats/domain/member/dto/MemberResponseDto.java
@@ -1,5 +1,0 @@
-package com.sparta.spangeats.domain.member.dto;
-
-public record MemberResponseDto() {
-
-}

--- a/src/main/java/com/sparta/spangeats/domain/member/dto/SignoutRequestDto.java
+++ b/src/main/java/com/sparta/spangeats/domain/member/dto/SignoutRequestDto.java
@@ -1,4 +1,0 @@
-package com.sparta.spangeats.domain.member.dto;
-
-public record SignoutRequestDto(String password) {
-}

--- a/src/main/java/com/sparta/spangeats/domain/member/dto/request/MemberRequestDto.java
+++ b/src/main/java/com/sparta/spangeats/domain/member/dto/request/MemberRequestDto.java
@@ -1,0 +1,4 @@
+package com.sparta.spangeats.domain.member.dto.request;
+
+public record MemberRequestDto() {
+}

--- a/src/main/java/com/sparta/spangeats/domain/member/dto/request/SignoutRequestDto.java
+++ b/src/main/java/com/sparta/spangeats/domain/member/dto/request/SignoutRequestDto.java
@@ -1,0 +1,4 @@
+package com.sparta.spangeats.domain.member.dto.request;
+
+public record SignoutRequestDto(String password) {
+}

--- a/src/main/java/com/sparta/spangeats/domain/member/dto/response/MemberInfoResponseDto.java
+++ b/src/main/java/com/sparta/spangeats/domain/member/dto/response/MemberInfoResponseDto.java
@@ -2,8 +2,12 @@ package com.sparta.spangeats.domain.member.dto.response;
 
 import com.sparta.spangeats.domain.member.enums.MemberRole;
 
+import java.time.LocalDateTime;
+
 public record MemberInfoResponseDto(String email,
                                     String nickname,
                                     String phoneNumber,
-                                    MemberRole memberRole) {
+                                    MemberRole memberRole,
+                                    LocalDateTime createdAt,
+                                    LocalDateTime updatedAt) {
 }

--- a/src/main/java/com/sparta/spangeats/domain/member/dto/response/MemberInfoResponseDto.java
+++ b/src/main/java/com/sparta/spangeats/domain/member/dto/response/MemberInfoResponseDto.java
@@ -1,0 +1,9 @@
+package com.sparta.spangeats.domain.member.dto.response;
+
+import com.sparta.spangeats.domain.member.enums.MemberRole;
+
+public record MemberInfoResponseDto(String email,
+                                    String nickname,
+                                    String phoneNumber,
+                                    MemberRole memberRole) {
+}

--- a/src/main/java/com/sparta/spangeats/domain/member/service/MemberService.java
+++ b/src/main/java/com/sparta/spangeats/domain/member/service/MemberService.java
@@ -44,7 +44,9 @@ public class MemberService {
                 userDetails.getEmail(),
                 userDetails.getNickname(),
                 userDetails.getPhoneNumber(),
-                userDetails.getMemberRole()
+                userDetails.getMemberRole(),
+                userDetails.getCreartedAt(),
+                userDetails.getUpdatedAt()
         );
     }
 }

--- a/src/main/java/com/sparta/spangeats/domain/member/service/MemberService.java
+++ b/src/main/java/com/sparta/spangeats/domain/member/service/MemberService.java
@@ -1,10 +1,7 @@
 package com.sparta.spangeats.domain.member.service;
 
-import com.sparta.spangeats.domain.auth.dto.request.LoginRequestDto;
-import com.sparta.spangeats.domain.auth.dto.response.AuthResponseDto;
-import com.sparta.spangeats.domain.auth.exception.AuthException;
-import com.sparta.spangeats.domain.member.dto.SignoutRequestDto;
-import com.sparta.spangeats.domain.member.entity.Member;
+import com.sparta.spangeats.domain.member.dto.request.SignoutRequestDto;
+import com.sparta.spangeats.domain.member.dto.response.MemberInfoResponseDto;
 import com.sparta.spangeats.domain.member.enums.MemberStatus;
 import com.sparta.spangeats.domain.member.exception.MemberException;
 import com.sparta.spangeats.domain.member.repository.MemberRepository;
@@ -35,5 +32,19 @@ public class MemberService {
 
         userDetails.getMember().setMemberStatus(MemberStatus.DELETED);
         memberRepository.save(userDetails.getMember());
+    }
+
+    public MemberInfoResponseDto getMemberInfo(UserDetailsImpl userDetails) {
+
+        if (userDetails.getMember().getMemberStatus().equals(MemberStatus.DELETED)) {
+            throw new MemberException("이미 탈퇴한 사용자입니다.");
+        }
+
+        return new MemberInfoResponseDto(
+                userDetails.getEmail(),
+                userDetails.getNickname(),
+                userDetails.getPhoneNumber(),
+                userDetails.getMemberRole()
+        );
     }
 }

--- a/src/main/java/com/sparta/spangeats/security/filter/UserDetailsImpl.java
+++ b/src/main/java/com/sparta/spangeats/security/filter/UserDetailsImpl.java
@@ -9,6 +9,7 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
 
@@ -50,6 +51,14 @@ public class UserDetailsImpl implements UserDetails {
 
     public String getNickname() {
         return member.getNickname();
+    }
+
+    public LocalDateTime getCreartedAt() {
+        return member.getCreatedAt();
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return member.getUpdatedAt();
     }
 
     @Override

--- a/src/main/java/com/sparta/spangeats/security/filter/UserDetailsImpl.java
+++ b/src/main/java/com/sparta/spangeats/security/filter/UserDetailsImpl.java
@@ -48,6 +48,10 @@ public class UserDetailsImpl implements UserDetails {
         return member.getMemberStatus();
     }
 
+    public String getNickname() {
+        return member.getNickname();
+    }
+
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         MemberRole memberRole = member.getMemberRole();


### PR DESCRIPTION
Issue/35 - 회원 정보 조회 기능 추가

      - 회원 본인의 정보를 조회할 수 있는 기능 구현
      - UserDetailsImpl을 사용하여 인증된 사용자 정보에 접근
      - 회원 상태가 `DELETED`인 경우 조회 불가하도록 예외 처리
      - 응답 본문에 이메일, 닉네임, 전화번호, 역할, 생성일, 수정일이 포함되도록 설정
    
** 다음 작업 예정 **
- 회원 정보 수정 기능 추가 예정입니다