### PR TITLE
 feat: 회원 정보 수정 기능 구현

### DIFF
--- a/src/main/java/com/sparta/spangeats/domain/member/controller/MemberController.java
+++ b/src/main/java/com/sparta/spangeats/domain/member/controller/MemberController.java
@@ -1,8 +1,8 @@
 package com.sparta.spangeats.domain.member.controller;
 
 import com.sparta.spangeats.domain.member.dto.request.SignoutRequestDto;
+import com.sparta.spangeats.domain.member.dto.request.UpdateMemberRequestDto;
 import com.sparta.spangeats.domain.member.dto.response.MemberInfoResponseDto;
-import com.sparta.spangeats.domain.member.entity.Member;
 import com.sparta.spangeats.domain.member.service.MemberService;
 import com.sparta.spangeats.security.filter.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
@@ -32,6 +32,13 @@ public class MemberController {
 
         MemberInfoResponseDto responseDto = memberService.getMemberInfo(userDetails);
         return ResponseEntity.status(HttpStatus.OK).body(responseDto);
+    }
+
+    @PatchMapping
+    public ResponseEntity<String> updateMemberInfo(@RequestBody UpdateMemberRequestDto requestDto,
+                                                   @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        memberService.updateMemberInfo(requestDto, userDetails);
+        return ResponseEntity.status(HttpStatus.OK).body("회원 정보가 성공적으로 수정되었습니다.");
     }
 
 }

--- a/src/main/java/com/sparta/spangeats/domain/member/dto/request/MemberRequestDto.java
+++ b/src/main/java/com/sparta/spangeats/domain/member/dto/request/MemberRequestDto.java
@@ -1,4 +1,0 @@
-package com.sparta.spangeats.domain.member.dto.request;
-
-public record MemberRequestDto() {
-}

--- a/src/main/java/com/sparta/spangeats/domain/member/dto/request/UpdateMemberRequestDto.java
+++ b/src/main/java/com/sparta/spangeats/domain/member/dto/request/UpdateMemberRequestDto.java
@@ -3,19 +3,20 @@ package com.sparta.spangeats.domain.member.dto.request;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 
-public record UpdateMemberRequestDto(String nickname,
-                                     String phoneNumber,
+public record UpdateMemberRequestDto(
+        String nickname,
+        String phoneNumber,
 
-                                     @NotBlank
-                                     @Pattern(
-                                             regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,}$",
-                                             message = "비밀번호는 최소 8자리 이상이며, 대소문자, 숫자, 특수문자를 각각 최소 1개 이상 포함해야 합니다."
-                                     )
-                                     String currentPassword,
+        @NotBlank
+        @Pattern(
+                regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,}$",
+                message = "비밀번호는 최소 8자리 이상이며, 대소문자, 숫자, 특수문자를 각각 최소 1개 이상 포함해야 합니다."
+        )
+        String currentPassword,
 
-                                     @Pattern(
-                                             regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,}$",
-                                             message = "비밀번호는 최소 8자리 이상이며, 대소문자, 숫자, 특수문자를 각각 최소 1개 이상 포함해야 합니다."
-                                     )
-                                     String newPassword) {
+        @Pattern(
+                regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,}$",
+                message = "비밀번호는 최소 8자리 이상이며, 대소문자, 숫자, 특수문자를 각각 최소 1개 이상 포함해야 합니다."
+        )
+        String newPassword) {
 }

--- a/src/main/java/com/sparta/spangeats/domain/member/dto/request/UpdateMemberRequestDto.java
+++ b/src/main/java/com/sparta/spangeats/domain/member/dto/request/UpdateMemberRequestDto.java
@@ -1,0 +1,21 @@
+package com.sparta.spangeats.domain.member.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record UpdateMemberRequestDto(String nickname,
+                                     String phoneNumber,
+
+                                     @NotBlank
+                                     @Pattern(
+                                             regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,}$",
+                                             message = "비밀번호는 최소 8자리 이상이며, 대소문자, 숫자, 특수문자를 각각 최소 1개 이상 포함해야 합니다."
+                                     )
+                                     String currentPassword,
+
+                                     @Pattern(
+                                             regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,}$",
+                                             message = "비밀번호는 최소 8자리 이상이며, 대소문자, 숫자, 특수문자를 각각 최소 1개 이상 포함해야 합니다."
+                                     )
+                                     String newPassword) {
+}

--- a/src/main/java/com/sparta/spangeats/domain/member/entity/Member.java
+++ b/src/main/java/com/sparta/spangeats/domain/member/entity/Member.java
@@ -50,4 +50,11 @@ public class Member extends Timestamped {
     public boolean isValidMemberRole() {
         return this.memberRole.equals(MemberRole.OWNER);
     }
+
+    public boolean isValidNickName(String updateNickName, String currentNickName) {
+        if (updateNickName != null && updateNickName.equals(currentNickName)) {
+            return false;
+        }
+        return true;
+    }
 }

--- a/src/main/java/com/sparta/spangeats/domain/member/service/MemberService.java
+++ b/src/main/java/com/sparta/spangeats/domain/member/service/MemberService.java
@@ -59,12 +59,24 @@ public class MemberService {
             throw new MemberException("현재 비밀번호가 일치하지 않습니다.");
         }
 
-        if (requestDto.nickname() != null && requestDto.nickname().equals(userDetails.getNickname())) {
+        if(!isNickNameVaild(requestDto, userDetails)) {
             throw new MemberException("이미 사용 중인 닉네임입니다.");
         }
 
         Member member = userDetails.getMember();
+        setMemberFields(requestDto, member);
 
+        memberRepository.save(member);
+    }
+
+    private boolean isNickNameVaild (UpdateMemberRequestDto requestDto, UserDetailsImpl userDetails) {
+        if (requestDto.nickname() != null && requestDto.nickname().equals(userDetails.getNickname())) {
+            return false;
+        }
+        return true;
+    }
+
+    private void setMemberFields (UpdateMemberRequestDto requestDto, Member member) {
         if (requestDto.nickname() != null) {
             member.setNickname(requestDto.nickname());
         }
@@ -76,7 +88,5 @@ public class MemberService {
         if (requestDto.newPassword() != null) {
             member.setPassword(passwordEncoder.encode(requestDto.newPassword()));
         }
-
-        memberRepository.save(member);
     }
 }

--- a/src/main/java/com/sparta/spangeats/domain/member/service/MemberService.java
+++ b/src/main/java/com/sparta/spangeats/domain/member/service/MemberService.java
@@ -1,7 +1,9 @@
 package com.sparta.spangeats.domain.member.service;
 
 import com.sparta.spangeats.domain.member.dto.request.SignoutRequestDto;
+import com.sparta.spangeats.domain.member.dto.request.UpdateMemberRequestDto;
 import com.sparta.spangeats.domain.member.dto.response.MemberInfoResponseDto;
+import com.sparta.spangeats.domain.member.entity.Member;
 import com.sparta.spangeats.domain.member.enums.MemberStatus;
 import com.sparta.spangeats.domain.member.exception.MemberException;
 import com.sparta.spangeats.domain.member.repository.MemberRepository;
@@ -48,5 +50,33 @@ public class MemberService {
                 userDetails.getCreartedAt(),
                 userDetails.getUpdatedAt()
         );
+    }
+
+    @Transactional
+    public void updateMemberInfo(UpdateMemberRequestDto requestDto, UserDetailsImpl userDetails) {
+
+        if (!passwordEncoder.matches(requestDto.currentPassword(), userDetails.getPassword())) {
+            throw new MemberException("현재 비밀번호가 일치하지 않습니다.");
+        }
+
+        if (requestDto.nickname() != null && requestDto.nickname().equals(userDetails.getNickname())) {
+            throw new MemberException("이미 사용 중인 닉네임입니다.");
+        }
+
+        Member member = userDetails.getMember();
+
+        if (requestDto.nickname() != null) {
+            member.setNickname(requestDto.nickname());
+        }
+
+        if (requestDto.phoneNumber() != null) {
+            member.setPhoneNumber(requestDto.phoneNumber());
+        }
+
+        if (requestDto.newPassword() != null) {
+            member.setPassword(passwordEncoder.encode(requestDto.newPassword()));
+        }
+
+        memberRepository.save(member);
     }
 }

--- a/src/main/java/com/sparta/spangeats/domain/member/service/MemberService.java
+++ b/src/main/java/com/sparta/spangeats/domain/member/service/MemberService.java
@@ -59,21 +59,15 @@ public class MemberService {
             throw new MemberException("현재 비밀번호가 일치하지 않습니다.");
         }
 
-        if(!isNickNameVaild(requestDto, userDetails)) {
+        Member member = userDetails.getMember();
+
+        if(!member.isValidNickName(requestDto.nickname(), userDetails.getNickname())) {
             throw new MemberException("이미 사용 중인 닉네임입니다.");
         }
 
-        Member member = userDetails.getMember();
         setMemberFields(requestDto, member);
 
         memberRepository.save(member);
-    }
-
-    private boolean isNickNameVaild (UpdateMemberRequestDto requestDto, UserDetailsImpl userDetails) {
-        if (requestDto.nickname() != null && requestDto.nickname().equals(userDetails.getNickname())) {
-            return false;
-        }
-        return true;
     }
 
     private void setMemberFields (UpdateMemberRequestDto requestDto, Member member) {


### PR DESCRIPTION
[#36] issue/36 - 회원 정보 수정 기능 구현

- 사용자가 수정 요청한 필드(닉네임, 전화번호, 비밀번호)에 대해 값이 있는 경우에만 업데이트하도록 설정
- 현재 비밀번호 확인을 통해 본인 인증 후 수정 가능하도록 검증 로직 추가
- 닉네임 중복 검사를 통해 이미 사용 중인 닉네임으로 수정하려는 경우 예외 처리
- 사용자가 선택적으로 수정할 수 있도록 null 체크를 통해 빈 필드는 변경하지 않음

** 다음 구현 예정 **
ADMIN 권한을 추가하여 ADMIN 기능 구현하기 : 전체 멤버 조회 기능 구현