### PR TITLE
feat: 전체 회원 조회 기능 구현

### DIFF
--- a/src/main/java/com/sparta/spangeats/domain/auth/dto/request/SignupRequestDto.java
+++ b/src/main/java/com/sparta/spangeats/domain/auth/dto/request/SignupRequestDto.java
@@ -23,6 +23,8 @@ public record SignupRequestDto(
         String memberRole,
 
         @NotBlank
-        String phoneNumber
+        String phoneNumber,
+
+        String adminSecretKey
 ) {
 }

--- a/src/main/java/com/sparta/spangeats/domain/member/controller/AdminMemberController.java
+++ b/src/main/java/com/sparta/spangeats/domain/member/controller/AdminMemberController.java
@@ -1,0 +1,35 @@
+package com.sparta.spangeats.domain.member.controller;
+
+import com.sparta.spangeats.domain.member.dto.response.AdminMemberInfoResponse;
+import com.sparta.spangeats.domain.member.service.MemberService;
+import com.sparta.spangeats.security.filter.UserDetailsImpl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@PreAuthorize("hasRole('ADMIN')")
+@RequestMapping("/api/admin")
+public class AdminMemberController {
+
+    private final MemberService memberService;
+
+    @GetMapping("/member")
+    public ResponseEntity<List<AdminMemberInfoResponse>> getAllMemberInfo(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                                          @RequestParam int page,
+                                                                          @RequestParam int size) {
+        List<AdminMemberInfoResponse> memberInfoResponseList = memberService.getAllMemberInfo(userDetails, page, size);
+        return ResponseEntity.status(HttpStatus.OK).body(memberInfoResponseList);
+    }
+
+
+}

--- a/src/main/java/com/sparta/spangeats/domain/member/controller/MemberController.java
+++ b/src/main/java/com/sparta/spangeats/domain/member/controller/MemberController.java
@@ -2,9 +2,11 @@ package com.sparta.spangeats.domain.member.controller;
 
 import com.sparta.spangeats.domain.member.dto.request.SignoutRequestDto;
 import com.sparta.spangeats.domain.member.dto.request.UpdateMemberRequestDto;
+import com.sparta.spangeats.domain.member.dto.response.AdminMemberInfoResponse;
 import com.sparta.spangeats.domain.member.dto.response.MemberInfoResponseDto;
 import com.sparta.spangeats.domain.member.service.MemberService;
 import com.sparta.spangeats.security.filter.UserDetailsImpl;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -21,7 +23,6 @@ public class MemberController {
     @DeleteMapping("/signout")
     public ResponseEntity<String> signout(@RequestBody SignoutRequestDto requestDto,
                                           @AuthenticationPrincipal UserDetailsImpl userDetails) {
-
         memberService.signout(requestDto, userDetails);
         return ResponseEntity.status(HttpStatus.OK).body("회원 탈퇴 완료! 중복된 이메일로 재가입이 불가합니다.");
 
@@ -29,13 +30,12 @@ public class MemberController {
 
     @GetMapping
     public ResponseEntity<MemberInfoResponseDto> getMemberInfo(@AuthenticationPrincipal UserDetailsImpl userDetails) {
-
         MemberInfoResponseDto responseDto = memberService.getMemberInfo(userDetails);
         return ResponseEntity.status(HttpStatus.OK).body(responseDto);
     }
 
     @PatchMapping
-    public ResponseEntity<String> updateMemberInfo(@RequestBody UpdateMemberRequestDto requestDto,
+    public ResponseEntity<String> updateMemberInfo(@Valid @RequestBody UpdateMemberRequestDto requestDto,
                                                    @AuthenticationPrincipal UserDetailsImpl userDetails) {
         memberService.updateMemberInfo(requestDto, userDetails);
         return ResponseEntity.status(HttpStatus.OK).body("회원 정보가 성공적으로 수정되었습니다.");

--- a/src/main/java/com/sparta/spangeats/domain/member/dto/response/AdminMemberInfoResponse.java
+++ b/src/main/java/com/sparta/spangeats/domain/member/dto/response/AdminMemberInfoResponse.java
@@ -1,14 +1,18 @@
 package com.sparta.spangeats.domain.member.dto.response;
 
 import com.sparta.spangeats.domain.member.enums.MemberRole;
+import com.sparta.spangeats.domain.member.enums.MemberStatus;
 
 import java.time.LocalDateTime;
 
-public record MemberInfoResponseDto(
+public record AdminMemberInfoResponse(
         String email,
+        String password,
         String nickname,
         String phoneNumber,
         MemberRole memberRole,
+        MemberStatus memberStatus,
         LocalDateTime createdAt,
-        LocalDateTime updatedAt) {
+        LocalDateTime updatedAt
+) {
 }

--- a/src/main/java/com/sparta/spangeats/domain/member/enums/MemberRole.java
+++ b/src/main/java/com/sparta/spangeats/domain/member/enums/MemberRole.java
@@ -1,5 +1,6 @@
 package com.sparta.spangeats.domain.member.enums;
 
+import com.sparta.spangeats.domain.auth.exception.AuthException;
 import lombok.RequiredArgsConstructor;
 
 import java.util.Arrays;
@@ -7,7 +8,8 @@ import java.util.Arrays;
 @RequiredArgsConstructor
 public enum MemberRole {
     USER(Authority.USER),
-    OWNER(Authority.OWNER);
+    OWNER(Authority.OWNER),
+    ADMIN(Authority.ADMIN);
 
     private final String authority;
 
@@ -19,6 +21,20 @@ public enum MemberRole {
                 .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 MemberRole : " + memberRole));
     }
 
+    /*
+    요청된 역할을 기반으로 사용자 역할을 반환하는 메서드
+    만약 요청된 역할이 ADMIN이라면 제공된 관리자 키가 유효한지 검증하고 ADMIN 역할을 반환
+     */
+    public static MemberRole from(String memberRole, String adminKey, String providedKey) {
+        if (ADMIN.name().equalsIgnoreCase(memberRole)) {
+            if(!adminKey.equals(providedKey)) {
+                throw new AuthException("유효하지 않은 관리자 키입니다.");
+            }
+            return ADMIN;
+        }
+        return MemberRole.of(memberRole);
+    }
+
     public String getAuthority() {
         return this.authority;
     }
@@ -26,5 +42,6 @@ public enum MemberRole {
     public static class Authority {
         public static final String USER = "USER";
         public static final String OWNER = "OWNER";
+        public static final String ADMIN = "ADMIN";
     }
 }

--- a/src/main/java/com/sparta/spangeats/domain/member/service/MemberService.java
+++ b/src/main/java/com/sparta/spangeats/domain/member/service/MemberService.java
@@ -2,16 +2,23 @@ package com.sparta.spangeats.domain.member.service;
 
 import com.sparta.spangeats.domain.member.dto.request.SignoutRequestDto;
 import com.sparta.spangeats.domain.member.dto.request.UpdateMemberRequestDto;
+import com.sparta.spangeats.domain.member.dto.response.AdminMemberInfoResponse;
 import com.sparta.spangeats.domain.member.dto.response.MemberInfoResponseDto;
 import com.sparta.spangeats.domain.member.entity.Member;
+import com.sparta.spangeats.domain.member.enums.MemberRole;
 import com.sparta.spangeats.domain.member.enums.MemberStatus;
 import com.sparta.spangeats.domain.member.exception.MemberException;
 import com.sparta.spangeats.domain.member.repository.MemberRepository;
 import com.sparta.spangeats.security.config.CustomPasswordEncoder;
 import com.sparta.spangeats.security.filter.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -52,6 +59,22 @@ public class MemberService {
         );
     }
 
+    public List<AdminMemberInfoResponse> getAllMemberInfo(UserDetailsImpl userDetails, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        return memberRepository.findAll(pageable).stream()
+                .map(member -> new AdminMemberInfoResponse(
+                        member.getEmail(),
+                        member.getPassword(),
+                        member.getNickname(),
+                        member.getPhoneNumber(),
+                        member.getMemberRole(),
+                        member.getMemberStatus(),
+                        member.getCreatedAt(),
+                        member.getUpdatedAt()
+                ))
+                .collect(Collectors.toList());
+    }
+
     @Transactional
     public void updateMemberInfo(UpdateMemberRequestDto requestDto, UserDetailsImpl userDetails) {
 
@@ -61,7 +84,7 @@ public class MemberService {
 
         Member member = userDetails.getMember();
 
-        if(!member.isValidNickName(requestDto.nickname(), userDetails.getNickname())) {
+        if (!member.isValidNickName(requestDto.nickname(), userDetails.getNickname())) {
             throw new MemberException("이미 사용 중인 닉네임입니다.");
         }
 
@@ -70,7 +93,7 @@ public class MemberService {
         memberRepository.save(member);
     }
 
-    private void setMemberFields (UpdateMemberRequestDto requestDto, Member member) {
+    private void setMemberFields(UpdateMemberRequestDto requestDto, Member member) {
         if (requestDto.nickname() != null) {
             member.setNickname(requestDto.nickname());
         }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,3 +19,6 @@ jwt:
   secret:
     key: ${jwt.secret.key}
 
+admin:
+  secret:
+    key: H67G8JkLqTz93PdC0VmXNQw58B9dUe4S


### PR DESCRIPTION
[#43] issue/43

- ADMIN 권한을 가진 사용자가 모든 회원 정보를 조회할 수 있도록 전체 회원 조회 API 구현
- AdminMemberInfoResponse DTO 추가
- JwtAuthorizationFilter에서 토큰의 역할이 ADMIN인지 검증
- ADMIN 권한이 필요한 api 경로를 /api/admin으로 설정


다음으로  `소셜 로그인 구현 예정`