### PR TITLE
[#30] 리뷰 생성 기능 구현 및 테스트 코드 작성

### DIFF
--- a/src/main/java/com/sparta/spangeats/domain/member/entity/Member.java
+++ b/src/main/java/com/sparta/spangeats/domain/member/entity/Member.java
@@ -14,6 +14,7 @@ import lombok.Setter;
 @NoArgsConstructor
 @Table(name = "member")
 public class Member extends Timestamped {
+    @Setter
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 

--- a/src/main/java/com/sparta/spangeats/domain/order/entity/Order.java
+++ b/src/main/java/com/sparta/spangeats/domain/order/entity/Order.java
@@ -5,14 +5,13 @@ import com.sparta.spangeats.domain.address.entity.Address;
 import com.sparta.spangeats.domain.member.entity.Member;
 import com.sparta.spangeats.domain.store.entity.Store;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Table(name = "orders")
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
 public class Order extends Timestamped {
+    @Setter
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -41,6 +40,8 @@ public class Order extends Timestamped {
     @Enumerated(EnumType.STRING)
     private DeliveryType deliveryType;
 
+    @Setter
+    @Getter
     private Long reviewId;
 
     @Builder
@@ -55,13 +56,5 @@ public class Order extends Timestamped {
         this.storeRequest = storeRequest;
         this.paymentType = paymentType;
         this.deliveryType = deliveryType;
-    }
-
-    public void setReviewId(Long reviewId) {
-        this.reviewId = reviewId;
-    }
-
-    public Long getReviewId() {
-        return reviewId;
     }
 }

--- a/src/main/java/com/sparta/spangeats/domain/order/entity/Order.java
+++ b/src/main/java/com/sparta/spangeats/domain/order/entity/Order.java
@@ -56,4 +56,12 @@ public class Order extends Timestamped {
         this.paymentType = paymentType;
         this.deliveryType = deliveryType;
     }
+
+    public void setReviewId(Long reviewId) {
+        this.reviewId = reviewId;
+    }
+
+    public Long getReviewId() {
+        return reviewId;
+    }
 }

--- a/src/main/java/com/sparta/spangeats/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/sparta/spangeats/domain/review/controller/ReviewController.java
@@ -30,8 +30,8 @@ public class ReviewController {
         return ResponseEntity.ok(message);
     }
 
-    // 리뷰 조회(가게) 추가 구현 필요
-    @GetMapping("/store/{storeId}")
+    // 리뷰 조회(가게) 추가 구현 필요, 가게와 주문의 연관관계 형성 후 가능
+/*    @GetMapping("/store/{storeId}")
     public ResponseEntity<Page<ReviewResponse>> getALlForStore(
             @RequestParam(value = "page", defaultValue = "0") int page,
             @RequestParam(value = "size", defaultValue = "10") int size,
@@ -39,10 +39,10 @@ public class ReviewController {
             @RequestParam(value = "isAsc", defaultValue = "false") boolean isAsc,
             @PathVariable Long storeId) {
         return reviewService.getALlForStore(page, size, sortBy, isAsc, storeId);
-    }
+    }*/
 
     //리뷰 전체 조회(회원별) - 날짜순, 디폴트: 최신
-    /*@GetMapping("/get/review/member")
+    @GetMapping("/get/review/member")
     public ResponseEntity<Page<ReviewResponse>> getAllForMember(
             @RequestParam(value = "page", defaultValue = "0") int page,
             @RequestParam(value = "size", defaultValue = "10") int size,
@@ -52,7 +52,7 @@ public class ReviewController {
         Long memberId = userDetails.getMemberId();
         Page<ReviewResponse> reviews = reviewService.getAllForMember(page, size, sortBy, isAsc, memberId);
         return ResponseEntity.ok(reviews);
-    }*/
+    }
 
     @PatchMapping("/update/{reviewId}")
     public ResponseEntity<String> update(@PathVariable Long reviewId,

--- a/src/main/java/com/sparta/spangeats/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/sparta/spangeats/domain/review/controller/ReviewController.java
@@ -22,18 +22,25 @@ public class ReviewController {
 
     private final ReviewService reviewService;
 
-    // 리뷰 생성 , 리뷰 조회(가게) 리턴값으로 리턴
+
     @PostMapping("/save/param")
-    public ResponseEntity<String> saveReview(@RequestParam Long memberId, Long orderId,
+    public ResponseEntity<String> saveReview(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                             @RequestParam Long orderId,
                                              @Valid @RequestBody ReviewRequest requestDto) {
+        Long memberId = userDetails.getMemberId();
         String message = reviewService.saveReview(memberId, orderId, requestDto);
         return ResponseEntity.ok(message);
     }
 
     // 리뷰 조회(가게) 추가 구현 필요
     @GetMapping("/store/{storeId}")
-    public ResponseEntity<List<ReviewResponse>> getALlForStore(@PathVariable Long storeId) {
-        return ResponseEntity.ok(reviewService.getALlForStore(storeId));
+    public ResponseEntity<Page<ReviewResponse>> getALlForStore(
+            @RequestParam(value = "page", defaultValue = "0") int page,
+            @RequestParam(value = "size", defaultValue = "10") int size,
+            @RequestParam(value = "sortBy", defaultValue = "modifiedAt") String sortBy,
+            @RequestParam(value = "isAsc", defaultValue = "false") boolean isAsc,
+            @PathVariable Long storeId) {
+        return reviewService.getALlForStore(page, size, sortBy, isAsc, storeId);
     }
 
     //리뷰 전체 조회(회원별) - 날짜순, 디폴트: 최신
@@ -41,7 +48,7 @@ public class ReviewController {
     public ResponseEntity<Page<ReviewResponse>> getAllForMember(
             @RequestParam(value = "page", defaultValue = "0") int page,
             @RequestParam(value = "size", defaultValue = "10") int size,
-            @RequestParam(value = "sortBy",defaultValue = "modifiedAt") String sortBy,
+            @RequestParam(value = "sortBy", defaultValue = "modifiedAt") String sortBy,
             @RequestParam(value = "isAsc", defaultValue = "false") boolean isAsc,
             @AuthenticationPrincipal UserDetailsImpl userDetails) {
         Long memberId = userDetails.getMemberId();

--- a/src/main/java/com/sparta/spangeats/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/sparta/spangeats/domain/review/controller/ReviewController.java
@@ -11,8 +11,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-
 
 // 유저(1:n)와 오더(1:1)랑 연관 관계 있음. -> username, orderId 부분 수정 필요
 @RestController

--- a/src/main/java/com/sparta/spangeats/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/sparta/spangeats/domain/review/controller/ReviewController.java
@@ -30,8 +30,8 @@ public class ReviewController {
         return ResponseEntity.ok(message);
     }
 
-    // 리뷰 조회(가게) 추가 구현 필요, 가게와 주문의 연관관계 형성 후 가능
-/*    @GetMapping("/store/{storeId}")
+   //  리뷰 조회(가게) 추가 구현 필요, 가게와 주문의 연관관계 형성 후 가능
+    @GetMapping("/store/{storeId}")
     public ResponseEntity<Page<ReviewResponse>> getALlForStore(
             @RequestParam(value = "page", defaultValue = "0") int page,
             @RequestParam(value = "size", defaultValue = "10") int size,
@@ -39,7 +39,7 @@ public class ReviewController {
             @RequestParam(value = "isAsc", defaultValue = "false") boolean isAsc,
             @PathVariable Long storeId) {
         return reviewService.getALlForStore(page, size, sortBy, isAsc, storeId);
-    }*/
+    }
 
     //리뷰 전체 조회(회원별) - 날짜순, 디폴트: 최신
     @GetMapping("/get/review/member")

--- a/src/main/java/com/sparta/spangeats/domain/review/entity/Review.java
+++ b/src/main/java/com/sparta/spangeats/domain/review/entity/Review.java
@@ -1,15 +1,16 @@
 package com.sparta.spangeats.domain.review.entity;
 
 import com.sparta.spangeats.common.Timestamped;
-import com.sparta.spangeats.domain.member.entity.Member;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
 @Entity
 @NoArgsConstructor
 @Table(name = "review")
+@Setter
 public class Review extends Timestamped {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -18,18 +19,12 @@ public class Review extends Timestamped {
     private Long score;
     private String contents;
 
-    // @ManyToOne(fetch = FetchType.LAZY)
-    //@JoinColumn(name = "member_id", nullable = false)
-    //private Member member;
-
-//    @OneToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name = "todo_id", nullable = false)
     private Long orderId;
 
-//    private Long memberId;
+    private Long memberId;
 
     public Review(Long memberId, Long orderId, Long score, String contents) {
-//        this.memberId = memberId;
+        this.memberId = memberId;
         this.orderId = orderId;
         this.score = score;
         this.contents = contents;

--- a/src/main/java/com/sparta/spangeats/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/sparta/spangeats/domain/review/repository/ReviewRepository.java
@@ -5,7 +5,11 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
-    //Page<Review> findAllByMemberIdOrderByCreatedAtDesc(Long memberId, Pageable pageable);
+    Page<Review> findAllByMemberIdOrderByCreatedAtDesc(Long memberId, Pageable pageable);
+
+    Optional<Review> findByOrderId(Long orderId);
 }

--- a/src/main/java/com/sparta/spangeats/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/sparta/spangeats/domain/review/repository/ReviewRepository.java
@@ -12,4 +12,6 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     Page<Review> findAllByMemberIdOrderByCreatedAtDesc(Long memberId, Pageable pageable);
 
     Optional<Review> findByOrderId(Long orderId);
+
+    boolean existsByOrderId(Long orderId);
 }

--- a/src/main/java/com/sparta/spangeats/domain/review/service/ReviewService.java
+++ b/src/main/java/com/sparta/spangeats/domain/review/service/ReviewService.java
@@ -48,7 +48,7 @@ public class ReviewService {
         return "리뷰가 생성되었습니다.";
     }
 
-/*  가게와 주문의 연관관계 형성 후 가능
+//  가게와 주문의 연관관계 형성 후 가능
     public ResponseEntity<Page<ReviewResponse>> getALlForStore(int page, int size, String sortBy, boolean isAsc, Long storeId) {
         Sort.Direction direction = isAsc ? Sort.Direction.ASC : Sort.Direction.DESC;
         Sort sort = Sort.by(direction, sortBy);
@@ -75,7 +75,7 @@ public class ReviewService {
         Page<ReviewResponse> pageResponse = new PageImpl<>(response.subList(start, end), pageable, response.size());
 
         return ResponseEntity.ok(pageResponse);
-    }*/
+    }
 
     public Page<ReviewResponse> getAllForMember(int page, int size, String sortBy, boolean isAsc, Long memberId) {
         Sort.Direction direction = isAsc ? Sort.Direction.ASC : Sort.Direction.DESC;

--- a/src/main/java/com/sparta/spangeats/domain/review/service/ReviewService.java
+++ b/src/main/java/com/sparta/spangeats/domain/review/service/ReviewService.java
@@ -48,6 +48,7 @@ public class ReviewService {
         return "리뷰가 생성되었습니다.";
     }
 
+/*  가게와 주문의 연관관계 형성 후 가능
     public ResponseEntity<Page<ReviewResponse>> getALlForStore(int page, int size, String sortBy, boolean isAsc, Long storeId) {
         Sort.Direction direction = isAsc ? Sort.Direction.ASC : Sort.Direction.DESC;
         Sort sort = Sort.by(direction, sortBy);
@@ -74,17 +75,17 @@ public class ReviewService {
         Page<ReviewResponse> pageResponse = new PageImpl<>(response.subList(start, end), pageable, response.size());
 
         return ResponseEntity.ok(pageResponse);
-    }
+    }*/
 
-    /*public Page<ReviewResponse> getAllForMember(int page, int size, String sortBy, boolean isAsc, Long memberId) {
+    public Page<ReviewResponse> getAllForMember(int page, int size, String sortBy, boolean isAsc, Long memberId) {
         Sort.Direction direction = isAsc ? Sort.Direction.ASC : Sort.Direction.DESC;
         Sort sort = Sort.by(direction, sortBy);
         Pageable pageable = PageRequest.of(page, size, sort);
 
-        //Page<Review> reviewList = reviewRepository.findAllByMemberIdOrderByCreatedAtDesc(memberId, pageable);
+        Page<Review> reviewList = reviewRepository.findAllByMemberIdOrderByCreatedAtDesc(memberId, pageable);
 
         return reviewList.map(review -> ReviewResponse.create(review));
-    }*/
+    }
 
     @Transactional
     public String update(Long reviewId, ReviewRequest requestDto) {

--- a/src/main/java/com/sparta/spangeats/domain/review/service/ReviewService.java
+++ b/src/main/java/com/sparta/spangeats/domain/review/service/ReviewService.java
@@ -27,7 +27,8 @@ public class ReviewService {
         return "리뷰가 생성되었습니다.";
     }
 
-    // 추가 구현 필요
+    // 추가 구현 필요, 주문 하나 당 리뷰 하나를 작성할 수 있음. 리뷰는 가게와 연관관계 x,
+    // 하지만 가게에 따라 리뷰를 조회할 수 있어야함.....
     public List<ReviewResponse> getALlForStore(Long storeId) {
         return null;
     }

--- a/src/main/java/com/sparta/spangeats/domain/review/service/ReviewService.java
+++ b/src/main/java/com/sparta/spangeats/domain/review/service/ReviewService.java
@@ -1,5 +1,6 @@
 package com.sparta.spangeats.domain.review.service;
 
+import com.sparta.spangeats.domain.order.entity.Order;
 import com.sparta.spangeats.domain.order.repository.OrderRepository;
 import com.sparta.spangeats.domain.review.dto.ReviewRequest;
 import com.sparta.spangeats.domain.review.dto.ReviewResponse;
@@ -7,7 +8,6 @@ import com.sparta.spangeats.domain.review.entity.Review;
 import com.sparta.spangeats.domain.review.repository.ReviewRepository;
 import com.sparta.spangeats.domain.store.entity.Store;
 import com.sparta.spangeats.domain.store.repository.StoreRepository;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.*;
 import org.springframework.http.ResponseEntity;
@@ -27,10 +27,11 @@ public class ReviewService {
 
     @Transactional
     public String saveReview(Long memberId, Long orderId, ReviewRequest requestDto) {
+        Order order = orderRepository.findById(orderId).orElseThrow(() ->
+                new IllegalArgumentException("해당 주문을 찾을 수 없습니다."));
+
         Review review = reviewRepository.findByOrderId(orderId).orElseThrow(() ->
                 new IllegalArgumentException("해당 주문에 대해 이미 리뷰를 남기셨습니다."));
-
-        Order order = orderRepository.findById(orderId);
 
         Review savedReview = new Review(memberId, orderId, requestDto.score(), requestDto.contents());
 

--- a/src/main/java/com/sparta/spangeats/domain/review/service/ReviewService.java
+++ b/src/main/java/com/sparta/spangeats/domain/review/service/ReviewService.java
@@ -35,7 +35,7 @@ public class ReviewService {
 
         Review savedReview = new Review(memberId, orderId, requestDto.score(), requestDto.contents());
 
-        order.setReviewId(review.getId());
+        order.setReviewId(savedReview.getId());
 
         reviewRepository.save(savedReview);
         return "리뷰가 생성되었습니다.";

--- a/src/main/java/com/sparta/spangeats/domain/store/entity/Store.java
+++ b/src/main/java/com/sparta/spangeats/domain/store/entity/Store.java
@@ -3,6 +3,7 @@ package com.sparta.spangeats.domain.store.entity;
 import com.sparta.spangeats.common.Timestamped;
 import com.sparta.spangeats.domain.member.entity.Member;
 import com.sparta.spangeats.domain.menu.entity.Menu;
+import com.sparta.spangeats.domain.order.entity.Order;
 import com.sparta.spangeats.domain.store.dto.StoreRequestDto;
 import com.sparta.spangeats.domain.store.enums.StoreStatus;
 import jakarta.persistence.*;
@@ -48,8 +49,8 @@ public class Store extends Timestamped {
     @OneToMany(mappedBy = "store") // Store와 Menu의 연관관계
     private List<Menu> menus = new ArrayList<>();
 
-//     @OneToMany(mappedBy = "store") // Store와 Order의 연관관계
-//     private List<Order> orders = new ArrayList<>();
+     @OneToMany(mappedBy = "store") // Store와 Order의 연관관계
+     private List<Order> orders = new ArrayList<>();
 
 
     @ManyToOne // Store와 Member의 연관관계

--- a/src/main/java/com/sparta/spangeats/domain/store/entity/Store.java
+++ b/src/main/java/com/sparta/spangeats/domain/store/entity/Store.java
@@ -71,6 +71,22 @@ public class Store extends Timestamped {
         this.member = member;
     }
 
+    // 가게 생성시, requestDto -> 엔터티
+    public static Store from(StoreRequestDto requestDto) {
+        Store store = new Store();
+        store.initData(requestDto);
+        return store;
+    }
+
+
+    public void initData(StoreRequestDto requestDto) {
+        this.name = requestDto.name();
+        this.openTime = requestDto.openTime();
+        this.closeTime = requestDto.closeTime();
+        this.minOrderPrice = requestDto.minOrderPrice();
+        this.phoneNumber = requestDto.phoneNumber();
+        this.address = requestDto.address();
+    }
 
     // 가게정보 수정시, 수정된 requestDto -> 엔터티 (status 기본값 유지)
     public void updateData(StoreRequestDto requestDto) {

--- a/src/test/java/com/sparta/spangeats/review/ReviewTest.java
+++ b/src/test/java/com/sparta/spangeats/review/ReviewTest.java
@@ -1,0 +1,96 @@
+package com.sparta.spangeats.review;
+
+import com.sparta.spangeats.domain.member.entity.Member;
+import com.sparta.spangeats.domain.member.repository.MemberRepository;
+import com.sparta.spangeats.domain.order.repository.OrderRepository;
+import com.sparta.spangeats.domain.review.dto.ReviewRequest;
+import com.sparta.spangeats.domain.review.entity.Review;
+import com.sparta.spangeats.domain.review.repository.ReviewRepository;
+import com.sparta.spangeats.domain.review.service.ReviewService;
+import com.sparta.spangeats.domain.store.repository.StoreRepository;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@ExtendWith(MockitoExtension.class)
+public class ReviewTest {
+
+    @Mock ReviewRepository reviewRepository;
+    @Mock StoreRepository storeRepository;
+    @Mock OrderRepository orderRepository;
+    @Mock MemberRepository memberRepository;
+    @InjectMocks ReviewService reviewService;
+
+    Member member = new Member();
+    com.sparta.spangeats.domain.order.entity.Order order = new com.sparta.spangeats.domain.order.entity.Order();
+    Review review = new Review();
+
+    @Test
+    @DisplayName("리뷰 생성 - 성공")
+    @Order(1)
+    void testSaveReviewSuccess() {
+        // given
+        Long memberId = 1L;
+        Long orderId = 1L;
+        ReviewRequest requestDto = new ReviewRequest(5L, "test");
+
+        member.setId(memberId);
+        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+
+        order.setId(orderId);
+        given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+
+        given(reviewRepository.existsByOrderId(orderId)).willReturn(false);
+
+        Review savedReview = new Review(memberId, orderId, requestDto.score(), requestDto.contents());
+        savedReview.setId(1L);
+        given(reviewRepository.save(any(Review.class))).willReturn(savedReview);
+
+        // when
+        String result = reviewService.saveReview(memberId, orderId, requestDto);
+
+        // then
+        assertEquals("리뷰가 생성되었습니다.", result);
+        assertEquals("리뷰가 생성되었습니다.", result);
+        verify(reviewRepository).save(any(Review.class));
+    }
+
+    @Test
+    @DisplayName("가게 별 리뷰 조회 - 성공")
+    @Order(2)
+    void test2() {
+
+    }
+
+    @Test
+    @DisplayName("회원 별 리뷰 조회 - 성공")
+    @Order(3)
+    void test3() {
+
+    }
+
+    @Test
+    @DisplayName("리뷰 수정 - 성공")
+    @Order(4)
+    void test4() {
+
+    }
+
+    @Test
+    @DisplayName("리뷰 삭제 - 성공")
+    @Order(5)
+    void test5() {
+
+    }
+}


### PR DESCRIPTION
**완료 사항**
- 리뷰 생성 기능 구현
- 테스트 코드 완료
- Review 엔티티에서 Member 를 참조하는 것이 아니라 memberId 를 가지고 있는 것으로 구현, 마찬가지로 Order 를 참조하는 것이 아니라 orderId 를 가지고 있는 것으로 구현.
- Member 엔티티: 테스트를 위해 Setter 추가.
- Order 엔티티: 테스트를 위해 기본 생성자를 테스트에서도 쓸 수 있게 설정, 로직 구현 및 테스트를 위해 Setter, Getter 추가.
- ReviewService 및 ReviewRepository 에 existsByOrderId() 메서드 추가하여, 주문 하나당 리뷰를 1개 남길 수 있게 구현.

**보완점**
- 예외 처리 추가
- Member 나 Order 에서 Review 참조해야 한다면 로직 변경 필요.
- 나머지 서비스 메서드에 대한 테스트 구현
- 서비스 단에서 테스트하는 것을 목표로 하겠지만, 여유가 생긴다면 컨트롤러에서 요청 보내는 것도 추가.
- getALlForStore(), 가게 별 리뷰 조회 메서드의 로직을 간소화하기 위해 JPQL 사용 가능.