### PR TITLE
feat: 장바구니 초기화 / 상품 주문 구현 예정

### DIFF
--- a/src/main/java/com/sparta/spangeats/common/ErrorResponseDto.java
+++ b/src/main/java/com/sparta/spangeats/common/ErrorResponseDto.java
@@ -1,4 +1,4 @@
-package com.sparta.spangeats.domain.store.dto;
+package com.sparta.spangeats.common;
 
     public record ErrorResponseDto(String message) {
     }

--- a/src/main/java/com/sparta/spangeats/common/GlobalExceptionHandler.java
+++ b/src/main/java/com/sparta/spangeats/common/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
-package com.sparta.spangeats.domain.store.exception;
+package com.sparta.spangeats.common;
 
-import com.sparta.spangeats.domain.store.dto.ErrorResponseDto;
+import com.sparta.spangeats.domain.cart.exception.CartNotFoundException;
+import com.sparta.spangeats.domain.store.exception.StoreException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -15,4 +16,9 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
     }
 
+    @ExceptionHandler(CartNotFoundException.class)
+    public ResponseEntity<ErrorResponseDto> handleStoreExceptionCartNotFoundException(CartNotFoundException ex) {
+        ErrorResponseDto errorResponse = new ErrorResponseDto(ex.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorResponse);
+    }
 }

--- a/src/main/java/com/sparta/spangeats/domain/cart/controller/CartController.java
+++ b/src/main/java/com/sparta/spangeats/domain/cart/controller/CartController.java
@@ -1,9 +1,6 @@
 package com.sparta.spangeats.domain.cart.controller;
 
-import com.sparta.spangeats.domain.cart.dto.CartRetrieveResponse;
-import com.sparta.spangeats.domain.cart.dto.CartSaveRequest;
-import com.sparta.spangeats.domain.cart.dto.CartSaveResponse;
-import com.sparta.spangeats.domain.cart.dto.CartUpdateMenuRequest;
+import com.sparta.spangeats.domain.cart.dto.*;
 import com.sparta.spangeats.domain.cart.service.CartService;
 import com.sparta.spangeats.security.filter.UserDetailsImpl;
 import jakarta.validation.Valid;
@@ -37,11 +34,21 @@ public class CartController {
     }
 
     @PatchMapping("/{cartId}")
-    public ResponseEntity<String> UpdateMenuQuantity(
+    public ResponseEntity<String> UpdateMenuQuantityInCart(
             @PathVariable Long cartId,
             @Valid @RequestBody CartUpdateMenuRequest request,
-            @AuthenticationPrincipal UserDetailsImpl userDetails){
+            @AuthenticationPrincipal UserDetailsImpl userDetails
+    ){
         cartService.updateMenuQuantity(cartId, request, userDetails.getMember());
         return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+    @DeleteMapping("/{cartId}")
+    public ResponseEntity<String> deleteMenuInCart(
+            @PathVariable Long cartId,
+            @AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        cartService.deleteMenu(cartId, userDetails.getMember());
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
  }

--- a/src/main/java/com/sparta/spangeats/domain/cart/controller/CartController.java
+++ b/src/main/java/com/sparta/spangeats/domain/cart/controller/CartController.java
@@ -3,6 +3,7 @@ package com.sparta.spangeats.domain.cart.controller;
 import com.sparta.spangeats.domain.cart.dto.CartRetrieveResponse;
 import com.sparta.spangeats.domain.cart.dto.CartSaveRequest;
 import com.sparta.spangeats.domain.cart.dto.CartSaveResponse;
+import com.sparta.spangeats.domain.cart.dto.CartUpdateMenuRequest;
 import com.sparta.spangeats.domain.cart.service.CartService;
 import com.sparta.spangeats.security.filter.UserDetailsImpl;
 import jakarta.validation.Valid;
@@ -34,4 +35,13 @@ public class CartController {
         CartRetrieveResponse response = cartService.retrieve(userDetails.getMember());
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
-}
+
+    @PatchMapping("/{cartId}")
+    public ResponseEntity<String> UpdateMenuQuantity(
+            @PathVariable Long cartId,
+            @Valid @RequestBody CartUpdateMenuRequest request,
+            @AuthenticationPrincipal UserDetailsImpl userDetails){
+        cartService.updateMenuQuantity(cartId, request, userDetails.getMember());
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+ }

--- a/src/main/java/com/sparta/spangeats/domain/cart/dto/CartUpdateMenuRequest.java
+++ b/src/main/java/com/sparta/spangeats/domain/cart/dto/CartUpdateMenuRequest.java
@@ -1,0 +1,9 @@
+package com.sparta.spangeats.domain.cart.dto;
+
+import jakarta.validation.constraints.Min;
+
+public record CartUpdateMenuRequest(
+        @Min(value = 1, message = "수량은 최소 1개여야 합니다.")
+        Long quantity
+) {
+}

--- a/src/main/java/com/sparta/spangeats/domain/cart/entity/Cart.java
+++ b/src/main/java/com/sparta/spangeats/domain/cart/entity/Cart.java
@@ -1,5 +1,6 @@
 package com.sparta.spangeats.domain.cart.entity;
 
+import com.sparta.spangeats.common.Timestamped;
 import com.sparta.spangeats.domain.member.entity.Member;
 import com.sparta.spangeats.domain.menu.entity.Menu;
 import com.sparta.spangeats.domain.store.entity.Store;
@@ -12,7 +13,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Cart {
+public class Cart extends Timestamped {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/com/sparta/spangeats/domain/cart/entity/Cart.java
+++ b/src/main/java/com/sparta/spangeats/domain/cart/entity/Cart.java
@@ -45,4 +45,11 @@ public class Cart {
         this.quantity += additionalQuantity;
     }
 
+    public void updateMenuQuantity(Long quantity) {
+        this.quantity = quantity;
+    }
+
+    public boolean isValidMember(Long checkedMemberId, Long realMemberId) {
+        return checkedMemberId.equals(realMemberId);
+    }
 }

--- a/src/main/java/com/sparta/spangeats/domain/cart/exception/CartNotFoundException.java
+++ b/src/main/java/com/sparta/spangeats/domain/cart/exception/CartNotFoundException.java
@@ -1,0 +1,7 @@
+package com.sparta.spangeats.domain.cart.exception;
+
+public class CartNotFoundException extends RuntimeException{
+    public CartNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/sparta/spangeats/domain/cart/repository/CartRepository.java
+++ b/src/main/java/com/sparta/spangeats/domain/cart/repository/CartRepository.java
@@ -4,6 +4,7 @@ import com.sparta.spangeats.domain.cart.entity.Cart;
 import com.sparta.spangeats.domain.store.entity.Store;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -15,4 +16,6 @@ public interface CartRepository extends JpaRepository<Cart, Long> {
     List<Cart> findAllByMemberId(Long id);
 
     boolean existsByStoreIdAndMemberId(Long storeId, Long memberId);
+
+    void deleteAllByUpdatedAtBefore(LocalDateTime checkTime);
 }

--- a/src/main/java/com/sparta/spangeats/domain/cart/service/CartService.java
+++ b/src/main/java/com/sparta/spangeats/domain/cart/service/CartService.java
@@ -69,12 +69,23 @@ public class CartService {
     @Transactional
     public void updateMenuQuantity(Long cartId, CartUpdateMenuRequest request, Member member) {
         Cart cart = cartRepository.findById(cartId)
-                .orElseThrow(() -> new CartNotFoundException("해당 장바구니 내역을 찾을 수 없습니다. 메뉴, 가게 id: " + cartId));
+                .orElseThrow(() -> new CartNotFoundException("해당 장바구니 내역을 찾을 수 없습니다." + cartId));
         if (!cart.isValidMember(member.getId(), cart.getMember().getId())) {
             throw new ValidationException("수정할 권한이 없습니다.");
         }
         cart.updateMenuQuantity(request.quantity());
         cartRepository.save(cart);
+    }
+
+    @Transactional
+    public void deleteMenu(Long cartId, Member member) {
+        Cart cart = cartRepository.findById(cartId)
+                .orElseThrow(() -> new CartNotFoundException("해당 장바구니 내역을 찾을 수 없습니다." + cartId));
+        if (!cart.isValidMember(member.getId(), cart.getMember().getId())) {
+            throw new ValidationException("삭제할 권한이 없습니다.");
+        }
+
+        cartRepository.deleteById(cartId);
     }
 
     private boolean isDifferentStoreId(Long storeId, Long memberId) {

--- a/src/main/java/com/sparta/spangeats/domain/cart/service/CartService.java
+++ b/src/main/java/com/sparta/spangeats/domain/cart/service/CartService.java
@@ -1,17 +1,17 @@
 package com.sparta.spangeats.domain.cart.service;
 
-import com.sparta.spangeats.domain.cart.dto.CartItemResponse;
-import com.sparta.spangeats.domain.cart.dto.CartRetrieveResponse;
-import com.sparta.spangeats.domain.cart.dto.CartSaveRequest;
-import com.sparta.spangeats.domain.cart.dto.CartSaveResponse;
+import com.sparta.spangeats.domain.cart.dto.*;
 import com.sparta.spangeats.domain.cart.entity.Cart;
+import com.sparta.spangeats.domain.cart.exception.CartNotFoundException;
 import com.sparta.spangeats.domain.cart.repository.CartRepository;
 import com.sparta.spangeats.domain.member.entity.Member;
+import com.sparta.spangeats.domain.member.exception.MemberException;
 import com.sparta.spangeats.domain.menu.entity.Menu;
 import com.sparta.spangeats.domain.menu.repository.MenuRepository;
 import com.sparta.spangeats.domain.store.entity.Store;
 import com.sparta.spangeats.domain.store.exception.StoreException;
 import com.sparta.spangeats.domain.store.repository.StoreRepository;
+import jakarta.validation.ValidationException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -64,6 +64,17 @@ public class CartService {
                 .toList();
 
         return CartRetrieveResponse.of(cartItems, member);
+    }
+
+    @Transactional
+    public void updateMenuQuantity(Long cartId, CartUpdateMenuRequest request, Member member) {
+        Cart cart = cartRepository.findById(cartId)
+                .orElseThrow(() -> new CartNotFoundException("해당 장바구니 내역을 찾을 수 없습니다. 메뉴, 가게 id: " + cartId));
+        if (!cart.isValidMember(member.getId(), cart.getMember().getId())) {
+            throw new ValidationException("수정할 권한이 없습니다.");
+        }
+        cart.updateMenuQuantity(request.quantity());
+        cartRepository.save(cart);
     }
 
     private boolean isDifferentStoreId(Long storeId, Long memberId) {

--- a/src/main/java/com/sparta/spangeats/domain/cart/service/CartService.java
+++ b/src/main/java/com/sparta/spangeats/domain/cart/service/CartService.java
@@ -13,9 +13,12 @@ import com.sparta.spangeats.domain.store.exception.StoreException;
 import com.sparta.spangeats.domain.store.repository.StoreRepository;
 import jakarta.validation.ValidationException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -86,6 +89,13 @@ public class CartService {
         }
 
         cartRepository.deleteById(cartId);
+    }
+
+    @Transactional
+    @Scheduled(cron = "0 0 0 * * *")
+    public void clearExpiredCarts(){
+        LocalDateTime checkTime = LocalDateTime.now().minusHours(24);
+        cartRepository.deleteAllByUpdatedAtBefore(checkTime);
     }
 
     private boolean isDifferentStoreId(Long storeId, Long memberId) {

--- a/src/main/java/com/sparta/spangeats/domain/menu/entity/Menu.java
+++ b/src/main/java/com/sparta/spangeats/domain/menu/entity/Menu.java
@@ -6,8 +6,10 @@ import jakarta.persistence.*;
 import lombok.Getter;
 
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
+@Setter
 @Getter
 @NoArgsConstructor
 @Table(name = "menus")

--- a/src/main/java/com/sparta/spangeats/domain/store/controller/StoreController.java
+++ b/src/main/java/com/sparta/spangeats/domain/store/controller/StoreController.java
@@ -1,5 +1,6 @@
 package com.sparta.spangeats.domain.store.controller;
 
+import com.sparta.spangeats.common.ErrorResponseDto;
 import com.sparta.spangeats.domain.member.entity.Member;
 import com.sparta.spangeats.domain.store.dto.*;
 import com.sparta.spangeats.domain.store.exception.StoreException;
@@ -7,13 +8,11 @@ import com.sparta.spangeats.domain.store.service.StoreService;
 import com.sparta.spangeats.security.filter.UserDetailsImpl;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import java.security.Principal;
 import java.util.List;
 
 @RestController

--- a/src/main/java/com/sparta/spangeats/domain/store/entity/Store.java
+++ b/src/main/java/com/sparta/spangeats/domain/store/entity/Store.java
@@ -13,7 +13,6 @@ import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 
-
 @Getter
 @Entity
 @NoArgsConstructor

--- a/src/test/java/com/sparta/spangeats/carttest/CartServiceTest.java
+++ b/src/test/java/com/sparta/spangeats/carttest/CartServiceTest.java
@@ -1,4 +1,4 @@
-package com.sparta.spangeats.authtest.service;
+package com.sparta.spangeats.carttest;
 
 import com.sparta.spangeats.domain.cart.dto.CartSaveRequest;
 import com.sparta.spangeats.domain.cart.entity.Cart;


### PR DESCRIPTION
### 기능 설명
매일 자정마다 장바구니의 만료 상태를 확인한 후 만료 시에 장바구니 삭제하는 로직

### 변경 사항
- [x] cart에 Timestamped 상속
- [x] cartRepository, cartService 수정

Issue: #65 