### PR TITLE
feat: 카카오 소셜 로그인 기능 구현

### DIFF
--- a/src/main/java/com/sparta/spangeats/domain/auth/config/RestTemplateConfig.java
+++ b/src/main/java/com/sparta/spangeats/domain/auth/config/RestTemplateConfig.java
@@ -1,0 +1,21 @@
+package com.sparta.spangeats.domain.auth.config;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.Duration;
+
+@Configuration
+public class RestTemplateConfig {
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder restTemplateBuilder) {
+        return restTemplateBuilder
+                // RestTemplate 으로 외부 API 호출 시 일정 시간이 지나도 응답이 없을 때
+                // 무한 대기 상태 방지를 위해 강제 종료 설정
+                .setConnectTimeout(Duration.ofSeconds(10)) // 10초
+                .setReadTimeout(Duration.ofSeconds(10)) // 10초
+                .build();
+    }
+}

--- a/src/main/java/com/sparta/spangeats/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/sparta/spangeats/domain/auth/controller/AuthController.java
@@ -1,19 +1,21 @@
 package com.sparta.spangeats.domain.auth.controller;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.sparta.spangeats.domain.auth.dto.request.LoginRequestDto;
 import com.sparta.spangeats.domain.auth.dto.request.SignupRequestDto;
 import com.sparta.spangeats.domain.auth.dto.response.AuthResponseDto;
 import com.sparta.spangeats.domain.auth.service.AuthService;
+import com.sparta.spangeats.domain.auth.service.KakaoService;
+import com.sparta.spangeats.security.config.JwtUtil;
 import com.sparta.spangeats.security.filter.UserDetailsImpl;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
@@ -22,6 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final AuthService authService;
+    private final KakaoService kakaoService;
 
     @PostMapping("/signup")
     public ResponseEntity<String> signup(@Valid @RequestBody SignupRequestDto requestDto) {
@@ -35,5 +38,17 @@ public class AuthController {
         return ResponseEntity.status(HttpStatus.CREATED).body(bearerJwt);
     }
 
+    @GetMapping("/kakao/callback")
+    public ResponseEntity<String> kakaoLogin(@RequestParam String code,
+                                             HttpServletResponse response) throws JsonProcessingException {
+        String token = kakaoService.kakaoLogin(code);
+
+        Cookie cookie = new Cookie(JwtUtil.AUTHORIZATION_HEADER, token.substring(7));
+        cookie.setHttpOnly(true);
+        cookie.setPath("/");
+        response.addCookie(cookie); // 브라우저의 jwt 값이 set
+
+        return ResponseEntity.status(HttpStatus.OK).body(token + "\t\t\t 로그인 성공");
+    }
 
 }

--- a/src/main/java/com/sparta/spangeats/domain/auth/dto/response/KakaoMemberInfoDto.java
+++ b/src/main/java/com/sparta/spangeats/domain/auth/dto/response/KakaoMemberInfoDto.java
@@ -1,0 +1,8 @@
+package com.sparta.spangeats.domain.auth.dto.response;
+
+public record KakaoMemberInfoDto(
+        Long id,
+        String nickname,
+        String email
+) {
+}

--- a/src/main/java/com/sparta/spangeats/domain/auth/service/KakaoService.java
+++ b/src/main/java/com/sparta/spangeats/domain/auth/service/KakaoService.java
@@ -1,0 +1,168 @@
+package com.sparta.spangeats.domain.auth.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sparta.spangeats.domain.auth.dto.response.KakaoMemberInfoDto;
+import com.sparta.spangeats.domain.member.entity.Member;
+import com.sparta.spangeats.domain.member.enums.MemberRole;
+import com.sparta.spangeats.domain.member.repository.MemberRepository;
+import com.sparta.spangeats.security.config.CustomPasswordEncoder;
+import com.sparta.spangeats.security.config.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.RequestEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.util.UUID;
+
+@Slf4j(topic = "KAKAO Login")
+@Service
+@RequiredArgsConstructor
+public class KakaoService {
+
+    private final CustomPasswordEncoder passwordEncoder;
+    private final MemberRepository memberRepository;
+    private final RestTemplate restTemplate;
+    private final JwtUtil jwtUtil;
+
+    public String kakaoLogin(String code) throws JsonProcessingException {
+        // 1. "인가 코드"로 "액세스 토큰" 요청
+        String accessToken = getToken(code);
+        // 2. 토큰으로 카카오 API 호출 : "액세스 토큰"으로 "카카오 사용자 정보" 가져오기
+        KakaoMemberInfoDto kakaoMemberInfoDto = getKakaoMemberInfo(accessToken);
+        // 3. 필요시에 회원가입
+        Member kakaoMember = registerKakaoMemberIfNeeded(kakaoMemberInfoDto);
+        // 4. JWT 토큰 반환
+        String createToken = jwtUtil.createToken(kakaoMember.getEmail(), kakaoMember.getMemberRole());
+
+        return createToken;
+    }
+
+    // 엑세스 토큰 요청
+    private String getToken(String code) throws JsonProcessingException {
+        // 요청 URL 만들기
+        URI uri = UriComponentsBuilder
+                .fromUriString("https://kauth.kakao.com")
+                .path("/oauth/token")
+                .encode()
+                .build()
+                .toUri();
+
+        // HTTP Header 생성
+        HttpHeaders headers = new HttpHeaders();
+        // Kakao OAuth 토큰 요청을 위한 Content-Type 설정
+        headers.add("Content-Type", "application/x-www-form-urlencoded;charset=UTF-8");
+
+        // Http Body 생성
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "authorization_code");
+        body.add("client_id", "216d6970b2f9d144847c1e1b6d6111fe"); // REST API 키
+        body.add("redirect_uri", "http://localhost:8080/api/auth/kakao/callback");
+        body.add("code", code);
+
+        RequestEntity<MultiValueMap<String, String>> requestEntity = RequestEntity
+                .post(uri)
+                .headers(headers)
+                .body(body);
+
+        // HTTP 요청 보내기
+        ResponseEntity<String> response = restTemplate.exchange(
+                requestEntity,
+                String.class
+        );
+
+        // HTTP 응답 (JSON) -> 액세스 토큰 파싱
+        JsonNode jsonNode = new ObjectMapper().readTree(response.getBody());
+        return jsonNode.get("access_token").asText();
+
+    }
+
+    // 시용자 정보 요청
+    private KakaoMemberInfoDto getKakaoMemberInfo(String accessToken) throws JsonProcessingException {
+        // 요청 URL 만들기
+        URI uri = UriComponentsBuilder
+                .fromUriString("https://kapi.kakao.com")
+                .path("/v2/user/me")
+                .encode()
+                .build()
+                .toUri();
+
+        // HTTP Header 생성
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "Bearer " + accessToken);
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        RequestEntity<MultiValueMap<String, String>> requestEntity = RequestEntity
+                .post(uri)
+                .headers(headers)
+                .body(new LinkedMultiValueMap<>());
+
+        // HTTP 요청 보내기
+        ResponseEntity<String> response = restTemplate.exchange(
+                requestEntity,
+                String.class
+        );
+
+        /*
+           json 으로 온 응답에서 원하는 값만 뽑아 오는 것임
+           이 이외의 데이터가 필요하다면 json 형태를 보고 가져올 수 있다.
+           */
+        JsonNode jsonNode = new ObjectMapper().readTree(response.getBody());
+        Long id = jsonNode.get("id").asLong();
+        String nickname = jsonNode.get("properties")
+                .get("nickname").asText();
+        String email = jsonNode.get("kakao_account")
+                .get("email").asText();
+
+        log.info("카카오 사용자 정보: " + id + ", " + nickname + ", " + email);
+        return new KakaoMemberInfoDto(id, nickname, email);
+    }
+
+    // 회원가입 처리
+    private Member registerKakaoMemberIfNeeded(KakaoMemberInfoDto kakaoMemberInfo) {
+        // DB에 중복된 Kakao Id 가 있는지 확인
+        Long kakaoId = kakaoMemberInfo.id();
+        Member kakaoMember = memberRepository.findByKakaoId(kakaoId).orElse(null);
+
+        if (kakaoMember == null) {
+            // 카카오 사용자 email 과 동일한 email 을 가진 회원이 있는지 확인
+            String kakaoEmail = kakaoMemberInfo.email();
+            Member sameEmailMember = memberRepository.findByEmail(kakaoEmail).orElse(null);
+            if (sameEmailMember != null) {
+                kakaoMember = sameEmailMember;
+                // 기존 회원 정보에 카카오 아이디 추가
+                kakaoMember.setKakaoId(kakaoId);
+            } else {
+                // 신규 회원 가입
+                /*
+                random UUID로 생성한 비밀번호는 카카오 회원가입에 사용되지만
+                실제 로그인에 사용되지 않는다.
+                 */
+                String password = UUID.randomUUID().toString();
+                String EncodedPassword = passwordEncoder.encode(password);
+
+                String email = kakaoMemberInfo.email();
+
+                kakaoMember = new Member(
+                        kakaoMemberInfo.email(),
+                        EncodedPassword,
+                        kakaoMemberInfo.nickname(),
+                        MemberRole.USER,
+                        kakaoMemberInfo.id());
+            }
+
+            memberRepository.save(kakaoMember);
+        }
+
+        return kakaoMember;
+    }
+
+}

--- a/src/main/java/com/sparta/spangeats/domain/member/controller/MemberController.java
+++ b/src/main/java/com/sparta/spangeats/domain/member/controller/MemberController.java
@@ -20,7 +20,7 @@ public class MemberController {
 
     private final MemberService memberService;
 
-    @DeleteMapping("/signout")
+    @PatchMapping("/signout")
     public ResponseEntity<String> signout(@RequestBody SignoutRequestDto requestDto,
                                           @AuthenticationPrincipal UserDetailsImpl userDetails) {
         memberService.signout(requestDto, userDetails);

--- a/src/main/java/com/sparta/spangeats/domain/member/entity/Member.java
+++ b/src/main/java/com/sparta/spangeats/domain/member/entity/Member.java
@@ -30,11 +30,13 @@ public class Member extends Timestamped {
     @Enumerated(EnumType.STRING)
     private MemberRole memberRole;
 
-    @Column(nullable = false)
+    @Column
     private String phoneNumber;
 
     @Enumerated(EnumType.STRING)
     private MemberStatus memberStatus = MemberStatus.ACTIVE;
+
+    private Long kakaoId;
 
     public Member(String email, String password, String nickname, MemberRole role, String phoneNumber) {
         this.email = email;
@@ -42,6 +44,15 @@ public class Member extends Timestamped {
         this.nickname = nickname;
         this.memberRole = role;
         this.phoneNumber = phoneNumber;
+    }
+
+    // 카카오 회원 생성자
+    public Member(String email, String password, String nickname, MemberRole role, Long kakaoId) {
+        this.email = email;
+        this.password = password;
+        this.nickname = nickname;
+        this.memberRole = role;
+        this.kakaoId = kakaoId;
     }
 
     public MemberRole getRole() {

--- a/src/main/java/com/sparta/spangeats/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/sparta/spangeats/domain/member/repository/MemberRepository.java
@@ -17,4 +17,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByEmail(String email);
 
     boolean existsByNickname(String nickname);
+
+    Optional<Member> findByKakaoId(Long kakaoId);
 }


### PR DESCRIPTION
[#48] issue/48

- 카카오 API를 통한 소셜 로그인 기능 추가
- 액세스 토큰으로 카카오 사용자 정보(id,nicknam,email) 조회
- 멤버 엔티티에 kakaoId 칼럼 추가 (일반회원은 null)
- 기존 회원일 경우 해당 회원으로 로그인 처리(kakaoId set)
- JWT 토큰 발급 및 쿠키에 설정하여 전달

**추가 구현 사항**
- 기존에 동일 이메일이 있는 경우 통합 안내 메시지 표시 예정
- 글로벌 예외처리 예정