### PR TITLE
[#48] feat: 글로벌 예외처리 추가 및 회원 조회 dto에 kakaoId 필드 추가

### DIFF
--- a/src/main/java/com/sparta/spangeats/common/GlobalExceptionHandler.java
+++ b/src/main/java/com/sparta/spangeats/common/GlobalExceptionHandler.java
@@ -1,6 +1,5 @@
 package com.sparta.spangeats.common;
 
-import com.sparta.spangeats.domain.address.exception.AddressOverCountException;
 import com.sparta.spangeats.domain.cart.exception.CartNotFoundException;
 import com.sparta.spangeats.domain.store.exception.StoreException;
 import org.springframework.http.HttpStatus;
@@ -28,4 +27,29 @@ public class GlobalExceptionHandler {
         ErrorResponseDto errorResponse = new ErrorResponseDto(ex.getMessage());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
     }
+
+    @ExceptionHandler(MemberException.class)
+    public ResponseEntity<String> handleMemberException(MemberException ex) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ex.getMessage());
+    }
+
+    @ExceptionHandler(AuthException.class)
+    public ResponseEntity<String> handleMemberException(AuthException ex) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ex.getMessage());
+    }
+
+    // Validation 예외 처리
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, String>> handleValidationExceptions(MethodArgumentNotValidException ex) {
+        Map<String, String> errors = new HashMap<>();
+
+        // 각 필드 에러 메시지를 errors에 저장
+        for (FieldError error : ex.getBindingResult().getFieldErrors()) {
+            errors.put(error.getField(), error.getDefaultMessage());
+        }
+
+        // JSON 형식의 에러 응답 반환
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errors);
+    }
+
 }

--- a/src/main/java/com/sparta/spangeats/common/GlobalExceptionHandler.java
+++ b/src/main/java/com/sparta/spangeats/common/GlobalExceptionHandler.java
@@ -1,11 +1,19 @@
 package com.sparta.spangeats.common;
 
+import com.sparta.spangeats.domain.address.exception.AddressOverCountException;
+import com.sparta.spangeats.domain.auth.exception.AuthException;
 import com.sparta.spangeats.domain.cart.exception.CartNotFoundException;
+import com.sparta.spangeats.domain.member.exception.MemberException;
 import com.sparta.spangeats.domain.store.exception.StoreException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @ControllerAdvice
 public class GlobalExceptionHandler {
@@ -28,7 +36,7 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
     }
 
-    @ExceptionHandler(MemberException.class)
+    @ExceptionHandler(value = MemberException.class)
     public ResponseEntity<String> handleMemberException(MemberException ex) {
         return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ex.getMessage());
     }

--- a/src/main/java/com/sparta/spangeats/common/GlobalExceptionHandler.java
+++ b/src/main/java/com/sparta/spangeats/common/GlobalExceptionHandler.java
@@ -46,17 +46,14 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ex.getMessage());
     }
 
-    // Validation 예외 처리
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<Map<String, String>> handleValidationExceptions(MethodArgumentNotValidException ex) {
         Map<String, String> errors = new HashMap<>();
 
-        // 각 필드 에러 메시지를 errors에 저장
         for (FieldError error : ex.getBindingResult().getFieldErrors()) {
             errors.put(error.getField(), error.getDefaultMessage());
         }
 
-        // JSON 형식의 에러 응답 반환
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errors);
     }
 

--- a/src/main/java/com/sparta/spangeats/domain/auth/config/RestTemplateConfig.java
+++ b/src/main/java/com/sparta/spangeats/domain/auth/config/RestTemplateConfig.java
@@ -12,10 +12,8 @@ public class RestTemplateConfig {
     @Bean
     public RestTemplate restTemplate(RestTemplateBuilder restTemplateBuilder) {
         return restTemplateBuilder
-                // RestTemplate 으로 외부 API 호출 시 일정 시간이 지나도 응답이 없을 때
-                // 무한 대기 상태 방지를 위해 강제 종료 설정
-                .setConnectTimeout(Duration.ofSeconds(10)) // 10초
-                .setReadTimeout(Duration.ofSeconds(10)) // 10초
+                .setConnectTimeout(Duration.ofSeconds(5))
+                .setReadTimeout(Duration.ofSeconds(5))
                 .build();
     }
 }

--- a/src/main/java/com/sparta/spangeats/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/sparta/spangeats/domain/auth/controller/AuthController.java
@@ -7,7 +7,6 @@ import com.sparta.spangeats.domain.auth.dto.response.AuthResponseDto;
 import com.sparta.spangeats.domain.auth.service.AuthService;
 import com.sparta.spangeats.domain.auth.service.KakaoService;
 import com.sparta.spangeats.security.config.JwtUtil;
-import com.sparta.spangeats.security.filter.UserDetailsImpl;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
@@ -46,7 +45,7 @@ public class AuthController {
         Cookie cookie = new Cookie(JwtUtil.AUTHORIZATION_HEADER, token.substring(7));
         cookie.setHttpOnly(true);
         cookie.setPath("/");
-        response.addCookie(cookie); // 브라우저의 jwt 값이 set
+        response.addCookie(cookie);
 
         return ResponseEntity.status(HttpStatus.OK).body(token + "\t\t\t 로그인 성공");
     }

--- a/src/main/java/com/sparta/spangeats/domain/auth/service/AuthService.java
+++ b/src/main/java/com/sparta/spangeats/domain/auth/service/AuthService.java
@@ -6,13 +6,9 @@ import com.sparta.spangeats.domain.auth.dto.response.AuthResponseDto;
 import com.sparta.spangeats.domain.auth.exception.AuthException;
 import com.sparta.spangeats.domain.member.entity.Member;
 import com.sparta.spangeats.domain.member.enums.MemberRole;
-import com.sparta.spangeats.domain.member.enums.MemberStatus;
-import com.sparta.spangeats.domain.member.exception.MemberException;
 import com.sparta.spangeats.domain.member.repository.MemberRepository;
 import com.sparta.spangeats.security.config.CustomPasswordEncoder;
 import com.sparta.spangeats.security.config.JwtUtil;
-import com.sparta.spangeats.security.filter.UserDetailsImpl;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -40,16 +36,14 @@ public class AuthService {
             throw new AuthException("이미 존재하는 닉네임 입니다.");
         }
 
-        // 관리자 역할 검증 및 반환
         MemberRole memberRole = MemberRole.from(
                 requestDto.memberRole(),
-                adminKey, // 실제 관리자 키
-                requestDto.adminSecretKey() // 요청에서 받은 관리자 키
+                adminKey,
+                requestDto.adminSecretKey()
         );
 
         String encodedPassword = passwordEncoder.encode(requestDto.password());
 
-        // 사용자 등록
         Member member = new Member(requestDto.email(),
                 encodedPassword,
                 requestDto.nickname(),

--- a/src/main/java/com/sparta/spangeats/domain/auth/service/KakaoService.java
+++ b/src/main/java/com/sparta/spangeats/domain/auth/service/KakaoService.java
@@ -34,21 +34,15 @@ public class KakaoService {
     private final JwtUtil jwtUtil;
 
     public String kakaoLogin(String code) throws JsonProcessingException {
-        // 1. "인가 코드"로 "액세스 토큰" 요청
         String accessToken = getToken(code);
-        // 2. 토큰으로 카카오 API 호출 : "액세스 토큰"으로 "카카오 사용자 정보" 가져오기
         KakaoMemberInfoDto kakaoMemberInfoDto = getKakaoMemberInfo(accessToken);
-        // 3. 필요시에 회원가입
         Member kakaoMember = registerKakaoMemberIfNeeded(kakaoMemberInfoDto);
-        // 4. JWT 토큰 반환
         String createToken = jwtUtil.createToken(kakaoMember.getEmail(), kakaoMember.getMemberRole());
 
         return createToken;
     }
 
-    // 엑세스 토큰 요청
     private String getToken(String code) throws JsonProcessingException {
-        // 요청 URL 만들기
         URI uri = UriComponentsBuilder
                 .fromUriString("https://kauth.kakao.com")
                 .path("/oauth/token")
@@ -56,12 +50,9 @@ public class KakaoService {
                 .build()
                 .toUri();
 
-        // HTTP Header 생성
         HttpHeaders headers = new HttpHeaders();
-        // Kakao OAuth 토큰 요청을 위한 Content-Type 설정
         headers.add("Content-Type", "application/x-www-form-urlencoded;charset=UTF-8");
 
-        // Http Body 생성
         MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
         body.add("grant_type", "authorization_code");
         body.add("client_id", "216d6970b2f9d144847c1e1b6d6111fe"); // REST API 키
@@ -73,21 +64,17 @@ public class KakaoService {
                 .headers(headers)
                 .body(body);
 
-        // HTTP 요청 보내기
         ResponseEntity<String> response = restTemplate.exchange(
                 requestEntity,
                 String.class
         );
 
-        // HTTP 응답 (JSON) -> 액세스 토큰 파싱
         JsonNode jsonNode = new ObjectMapper().readTree(response.getBody());
         return jsonNode.get("access_token").asText();
 
     }
 
-    // 시용자 정보 요청
     private KakaoMemberInfoDto getKakaoMemberInfo(String accessToken) throws JsonProcessingException {
-        // 요청 URL 만들기
         URI uri = UriComponentsBuilder
                 .fromUriString("https://kapi.kakao.com")
                 .path("/v2/user/me")
@@ -95,7 +82,6 @@ public class KakaoService {
                 .build()
                 .toUri();
 
-        // HTTP Header 생성
         HttpHeaders headers = new HttpHeaders();
         headers.add("Authorization", "Bearer " + accessToken);
         headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
@@ -105,16 +91,12 @@ public class KakaoService {
                 .headers(headers)
                 .body(new LinkedMultiValueMap<>());
 
-        // HTTP 요청 보내기
         ResponseEntity<String> response = restTemplate.exchange(
                 requestEntity,
                 String.class
         );
 
-        /*
-           json 으로 온 응답에서 원하는 값만 뽑아 오는 것임
-           이 이외의 데이터가 필요하다면 json 형태를 보고 가져올 수 있다.
-           */
+
         JsonNode jsonNode = new ObjectMapper().readTree(response.getBody());
         Long id = jsonNode.get("id").asLong();
         String nickname = jsonNode.get("properties")
@@ -126,26 +108,17 @@ public class KakaoService {
         return new KakaoMemberInfoDto(id, nickname, email);
     }
 
-    // 회원가입 처리
     private Member registerKakaoMemberIfNeeded(KakaoMemberInfoDto kakaoMemberInfo) {
-        // DB에 중복된 Kakao Id 가 있는지 확인
         Long kakaoId = kakaoMemberInfo.id();
         Member kakaoMember = memberRepository.findByKakaoId(kakaoId).orElse(null);
 
         if (kakaoMember == null) {
-            // 카카오 사용자 email 과 동일한 email 을 가진 회원이 있는지 확인
             String kakaoEmail = kakaoMemberInfo.email();
             Member sameEmailMember = memberRepository.findByEmail(kakaoEmail).orElse(null);
             if (sameEmailMember != null) {
                 kakaoMember = sameEmailMember;
-                // 기존 회원 정보에 카카오 아이디 추가
                 kakaoMember.setKakaoId(kakaoId);
             } else {
-                // 신규 회원 가입
-                /*
-                random UUID로 생성한 비밀번호는 카카오 회원가입에 사용되지만
-                실제 로그인에 사용되지 않는다.
-                 */
                 String password = UUID.randomUUID().toString();
                 String EncodedPassword = passwordEncoder.encode(password);
 

--- a/src/main/java/com/sparta/spangeats/domain/member/controller/MemberController.java
+++ b/src/main/java/com/sparta/spangeats/domain/member/controller/MemberController.java
@@ -2,7 +2,6 @@ package com.sparta.spangeats.domain.member.controller;
 
 import com.sparta.spangeats.domain.member.dto.request.SignoutRequestDto;
 import com.sparta.spangeats.domain.member.dto.request.UpdateMemberRequestDto;
-import com.sparta.spangeats.domain.member.dto.response.AdminMemberInfoResponse;
 import com.sparta.spangeats.domain.member.dto.response.MemberInfoResponseDto;
 import com.sparta.spangeats.domain.member.service.MemberService;
 import com.sparta.spangeats.security.filter.UserDetailsImpl;

--- a/src/main/java/com/sparta/spangeats/domain/member/dto/response/AdminMemberInfoResponse.java
+++ b/src/main/java/com/sparta/spangeats/domain/member/dto/response/AdminMemberInfoResponse.java
@@ -13,6 +13,7 @@ public record AdminMemberInfoResponse(
         MemberRole memberRole,
         MemberStatus memberStatus,
         LocalDateTime createdAt,
-        LocalDateTime updatedAt
+        LocalDateTime updatedAt,
+        Long kakaoId
 ) {
 }

--- a/src/main/java/com/sparta/spangeats/domain/member/dto/response/MemberInfoResponseDto.java
+++ b/src/main/java/com/sparta/spangeats/domain/member/dto/response/MemberInfoResponseDto.java
@@ -10,5 +10,6 @@ public record MemberInfoResponseDto(
         String phoneNumber,
         MemberRole memberRole,
         LocalDateTime createdAt,
-        LocalDateTime updatedAt) {
+        LocalDateTime updatedAt,
+        Long kakaoId) {
 }

--- a/src/main/java/com/sparta/spangeats/domain/member/enums/MemberRole.java
+++ b/src/main/java/com/sparta/spangeats/domain/member/enums/MemberRole.java
@@ -21,13 +21,9 @@ public enum MemberRole {
                 .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 MemberRole : " + memberRole));
     }
 
-    /*
-    요청된 역할을 기반으로 사용자 역할을 반환하는 메서드
-    만약 요청된 역할이 ADMIN이라면 제공된 관리자 키가 유효한지 검증하고 ADMIN 역할을 반환
-     */
     public static MemberRole from(String memberRole, String adminKey, String providedKey) {
         if (ADMIN.name().equalsIgnoreCase(memberRole)) {
-            if(!adminKey.equals(providedKey)) {
+            if (!adminKey.equals(providedKey)) {
                 throw new AuthException("유효하지 않은 관리자 키입니다.");
             }
             return ADMIN;

--- a/src/main/java/com/sparta/spangeats/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/sparta/spangeats/domain/member/repository/MemberRepository.java
@@ -1,13 +1,7 @@
 package com.sparta.spangeats.domain.member.repository;
 
 import com.sparta.spangeats.domain.member.entity.Member;
-import com.sparta.spangeats.domain.member.enums.MemberStatus;
-import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotBlank;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 

--- a/src/main/java/com/sparta/spangeats/domain/member/service/MemberService.java
+++ b/src/main/java/com/sparta/spangeats/domain/member/service/MemberService.java
@@ -5,7 +5,6 @@ import com.sparta.spangeats.domain.member.dto.request.UpdateMemberRequestDto;
 import com.sparta.spangeats.domain.member.dto.response.AdminMemberInfoResponse;
 import com.sparta.spangeats.domain.member.dto.response.MemberInfoResponseDto;
 import com.sparta.spangeats.domain.member.entity.Member;
-import com.sparta.spangeats.domain.member.enums.MemberRole;
 import com.sparta.spangeats.domain.member.enums.MemberStatus;
 import com.sparta.spangeats.domain.member.exception.MemberException;
 import com.sparta.spangeats.domain.member.repository.MemberRepository;

--- a/src/main/java/com/sparta/spangeats/domain/member/service/MemberService.java
+++ b/src/main/java/com/sparta/spangeats/domain/member/service/MemberService.java
@@ -55,7 +55,8 @@ public class MemberService {
                 userDetails.getPhoneNumber(),
                 userDetails.getMemberRole(),
                 userDetails.getCreartedAt(),
-                userDetails.getUpdatedAt()
+                userDetails.getUpdatedAt(),
+                userDetails.getMember().getKakaoId()
         );
     }
 
@@ -70,7 +71,8 @@ public class MemberService {
                         member.getMemberRole(),
                         member.getMemberStatus(),
                         member.getCreatedAt(),
-                        member.getUpdatedAt()
+                        member.getUpdatedAt(),
+                        member.getKakaoId()
                 ))
                 .collect(Collectors.toList());
     }

--- a/src/main/java/com/sparta/spangeats/security/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/sparta/spangeats/security/filter/JwtAuthorizationFilter.java
@@ -38,7 +38,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
 
             if (!jwtUtil.validateToken(tokenValue)) {
                 log.error("Token Error");
-                response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "유효하지 않은 토큰입니다.");
+                sendErrorResponse(response, HttpServletResponse.SC_UNAUTHORIZED, "유효하지 않은 토큰입니다.");
                 return;
             }
 
@@ -47,7 +47,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
             // ADMIN 권한이 필요한 경우 권한 검증
             if (requiresAdminRole(request) && !isAdmin(info)) {
                 log.error("접근 권한이 없습니다.");
-                response.sendError(HttpServletResponse.SC_FORBIDDEN, "접근 권한이 없습니다.");
+                sendErrorResponse(response, HttpServletResponse.SC_FORBIDDEN, "접근 권한이 없습니다.");
                 return;
             }
 
@@ -55,12 +55,20 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
                 setAuthentication(info.getSubject());
             } catch (Exception e) {
                 log.error(e.getMessage());
-                response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "인증 설정 오류");
+                sendErrorResponse(response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "인증 설정 오류");
                 return;
             }
 
         }
         filterChain.doFilter(request, response);
+    }
+
+    private void sendErrorResponse(HttpServletResponse response, int statusCode, String message) throws IOException {
+        response.setStatus(statusCode); // HTTP 상태 코드 설정
+        response.setContentType("application/json;charset=UTF-8"); // JSON 응답 타입 설정
+        response.getWriter().write(String.format("{\"error\": \"%s\"}", message)); // 에러 메시지 작성
+        response.getWriter().flush();
+        response.getWriter().close(); // writer 닫기
     }
 
     // ADMIN 권한 검증 메서드


### PR DESCRIPTION
- 각 필드의 유효성 오류 메시지를 응답 body에 반환하도록 설정
 - 요청에 대한 유효성 검사 실패 시 사용자에게 명확한 피드백 제공